### PR TITLE
GitHub actions: Don't install GNU make

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,10 +22,5 @@ jobs:
         with:
           go-version: "1.17.2"
 
-      - name: Install APT-based build dependencies
-        run: >
-          sudo apt-get update &&
-          sudo apt-get install make
-
       - name: Build and test
         run: make all check tidy check-dirty


### PR DESCRIPTION
### Applicable Issues
Fixes #5

### Description of the Change
The build-and-test.yml workflow unnecessarily installed GNU make even though it's already available thanks to the documented inclusion of the build-essential package for the Ubuntu virtual environment.

This added upwards of 10 s to the workflow execution. While the package installation itself is a no-op since the package is already installed the `apt-get update` operation takes time.

### Alternate Designs
None.

### Benefits
Slightly quicker workflow runs for PRs. No unnecessary cruft in the workflow.

### Possible Drawbacks
Aforementioned unnecessary cruft makes it easier to add new APT dependencies, should we need to do so. No need to look up what the YAML should look like if you don't know it by heart.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
