### PR TITLE
README: Add "Go Reference" badge to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 <img src="./images/logo.png" alt="Eiffel Events SDK – Go" width="350"/>
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/eiffel-community/eiffelevents-sdk-go.svg)](https://pkg.go.dev/github.com/eiffel-community/eiffelevents-sdk-go)
 [![Sandbox badge](https://img.shields.io/badge/Stage-Sandbox-yellow)](https://github.com/eiffel-community/community/blob/master/PROJECT_LIFECYCLE.md#stage-sandbox)
 
 # Eiffel Events SDK – Go


### PR DESCRIPTION
### Applicable Issues
Fixes #13 

### Description of the Change
Adding a Go Reference badge to the README will make it easier for folks to find the module's pkg.go.dev
documentation page. See it in action at https://github.com/magnusbaeck/eiffelevents-sdk-go/tree/go-ref-badge.

### Alternate Designs
None.

### Benefits
Makes it easier for folks to find the documentation.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
