### PR TITLE
Add modifier support to generated factories

### DIFF
--- a/EiffelActivityCanceledEventV1.go
+++ b/EiffelActivityCanceledEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewActivityCanceledV1() (*ActivityCanceledV1, error) {
+func NewActivityCanceledV1(modifiers ...Modifier) (*ActivityCanceledV1, error) {
 	var event ActivityCanceledV1
 	event.Meta.Type = "EiffelActivityCanceledEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityCanceledV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityCanceledV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityCanceledV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityCanceledV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityCanceledV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityCanceledV1{}
 
 type ActivityCanceledV1 struct {
 	// Mandatory fields

--- a/EiffelActivityCanceledEventV2.go
+++ b/EiffelActivityCanceledEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewActivityCanceledV2() (*ActivityCanceledV2, error) {
+func NewActivityCanceledV2(modifiers ...Modifier) (*ActivityCanceledV2, error) {
 	var event ActivityCanceledV2
 	event.Meta.Type = "EiffelActivityCanceledEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityCanceledV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityCanceledV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityCanceledV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityCanceledV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityCanceledV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityCanceledV2{}
 
 type ActivityCanceledV2 struct {
 	// Mandatory fields

--- a/EiffelActivityCanceledEventV3.go
+++ b/EiffelActivityCanceledEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewActivityCanceledV3() (*ActivityCanceledV3, error) {
+func NewActivityCanceledV3(modifiers ...Modifier) (*ActivityCanceledV3, error) {
 	var event ActivityCanceledV3
 	event.Meta.Type = "EiffelActivityCanceledEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityCanceledV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityCanceledV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityCanceledV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityCanceledV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityCanceledV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityCanceledV3{}
 
 type ActivityCanceledV3 struct {
 	// Mandatory fields

--- a/EiffelActivityFinishedEventV1.go
+++ b/EiffelActivityFinishedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewActivityFinishedV1() (*ActivityFinishedV1, error) {
+func NewActivityFinishedV1(modifiers ...Modifier) (*ActivityFinishedV1, error) {
 	var event ActivityFinishedV1
 	event.Meta.Type = "EiffelActivityFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityFinishedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityFinishedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityFinishedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityFinishedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityFinishedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityFinishedV1{}
 
 type ActivityFinishedV1 struct {
 	// Mandatory fields

--- a/EiffelActivityFinishedEventV2.go
+++ b/EiffelActivityFinishedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewActivityFinishedV2() (*ActivityFinishedV2, error) {
+func NewActivityFinishedV2(modifiers ...Modifier) (*ActivityFinishedV2, error) {
 	var event ActivityFinishedV2
 	event.Meta.Type = "EiffelActivityFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityFinishedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityFinishedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityFinishedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityFinishedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityFinishedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityFinishedV2{}
 
 type ActivityFinishedV2 struct {
 	// Mandatory fields

--- a/EiffelActivityFinishedEventV3.go
+++ b/EiffelActivityFinishedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewActivityFinishedV3() (*ActivityFinishedV3, error) {
+func NewActivityFinishedV3(modifiers ...Modifier) (*ActivityFinishedV3, error) {
 	var event ActivityFinishedV3
 	event.Meta.Type = "EiffelActivityFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityFinishedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityFinishedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityFinishedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityFinishedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityFinishedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityFinishedV3{}
 
 type ActivityFinishedV3 struct {
 	// Mandatory fields

--- a/EiffelActivityStartedEventV1.go
+++ b/EiffelActivityStartedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewActivityStartedV1() (*ActivityStartedV1, error) {
+func NewActivityStartedV1(modifiers ...Modifier) (*ActivityStartedV1, error) {
 	var event ActivityStartedV1
 	event.Meta.Type = "EiffelActivityStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityStartedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityStartedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityStartedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityStartedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityStartedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityStartedV1{}
 
 type ActivityStartedV1 struct {
 	// Mandatory fields

--- a/EiffelActivityStartedEventV2.go
+++ b/EiffelActivityStartedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewActivityStartedV2() (*ActivityStartedV2, error) {
+func NewActivityStartedV2(modifiers ...Modifier) (*ActivityStartedV2, error) {
 	var event ActivityStartedV2
 	event.Meta.Type = "EiffelActivityStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityStartedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityStartedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityStartedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityStartedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityStartedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityStartedV2{}
 
 type ActivityStartedV2 struct {
 	// Mandatory fields

--- a/EiffelActivityStartedEventV3.go
+++ b/EiffelActivityStartedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewActivityStartedV3() (*ActivityStartedV3, error) {
+func NewActivityStartedV3(modifiers ...Modifier) (*ActivityStartedV3, error) {
 	var event ActivityStartedV3
 	event.Meta.Type = "EiffelActivityStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityStartedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityStartedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityStartedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityStartedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityStartedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityStartedV3{}
 
 type ActivityStartedV3 struct {
 	// Mandatory fields

--- a/EiffelActivityStartedEventV4.go
+++ b/EiffelActivityStartedEventV4.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 4.x.x
 // currently known by this SDK.
-func NewActivityStartedV4() (*ActivityStartedV4, error) {
+func NewActivityStartedV4(modifiers ...Modifier) (*ActivityStartedV4, error) {
 	var event ActivityStartedV4
 	event.Meta.Type = "EiffelActivityStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][4].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityStartedV4: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityStartedV4) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityStartedV4) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityStartedV4) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityStartedV4) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityStartedV4{}
 
 type ActivityStartedV4 struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV1.go
+++ b/EiffelActivityTriggeredEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewActivityTriggeredV1() (*ActivityTriggeredV1, error) {
+func NewActivityTriggeredV1(modifiers ...Modifier) (*ActivityTriggeredV1, error) {
 	var event ActivityTriggeredV1
 	event.Meta.Type = "EiffelActivityTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityTriggeredV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityTriggeredV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityTriggeredV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityTriggeredV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityTriggeredV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityTriggeredV1{}
 
 type ActivityTriggeredV1 struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV2.go
+++ b/EiffelActivityTriggeredEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewActivityTriggeredV2() (*ActivityTriggeredV2, error) {
+func NewActivityTriggeredV2(modifiers ...Modifier) (*ActivityTriggeredV2, error) {
 	var event ActivityTriggeredV2
 	event.Meta.Type = "EiffelActivityTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityTriggeredV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityTriggeredV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityTriggeredV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityTriggeredV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityTriggeredV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityTriggeredV2{}
 
 type ActivityTriggeredV2 struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV3.go
+++ b/EiffelActivityTriggeredEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewActivityTriggeredV3() (*ActivityTriggeredV3, error) {
+func NewActivityTriggeredV3(modifiers ...Modifier) (*ActivityTriggeredV3, error) {
 	var event ActivityTriggeredV3
 	event.Meta.Type = "EiffelActivityTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityTriggeredV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityTriggeredV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityTriggeredV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityTriggeredV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityTriggeredV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityTriggeredV3{}
 
 type ActivityTriggeredV3 struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV4.go
+++ b/EiffelActivityTriggeredEventV4.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 4.x.x
 // currently known by this SDK.
-func NewActivityTriggeredV4() (*ActivityTriggeredV4, error) {
+func NewActivityTriggeredV4(modifiers ...Modifier) (*ActivityTriggeredV4, error) {
 	var event ActivityTriggeredV4
 	event.Meta.Type = "EiffelActivityTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][4].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ActivityTriggeredV4: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ActivityTriggeredV4) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ActivityTriggeredV4) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ActivityTriggeredV4) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ActivityTriggeredV4) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ActivityTriggeredV4{}
 
 type ActivityTriggeredV4 struct {
 	// Mandatory fields

--- a/EiffelAnnouncementPublishedEventV1.go
+++ b/EiffelAnnouncementPublishedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewAnnouncementPublishedV1() (*AnnouncementPublishedV1, error) {
+func NewAnnouncementPublishedV1(modifiers ...Modifier) (*AnnouncementPublishedV1, error) {
 	var event AnnouncementPublishedV1
 	event.Meta.Type = "EiffelAnnouncementPublishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new AnnouncementPublishedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *AnnouncementPublishedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *AnnouncementPublishedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *AnnouncementPublishedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *AnnouncementPublishedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &AnnouncementPublishedV1{}
 
 type AnnouncementPublishedV1 struct {
 	// Mandatory fields

--- a/EiffelAnnouncementPublishedEventV2.go
+++ b/EiffelAnnouncementPublishedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewAnnouncementPublishedV2() (*AnnouncementPublishedV2, error) {
+func NewAnnouncementPublishedV2(modifiers ...Modifier) (*AnnouncementPublishedV2, error) {
 	var event AnnouncementPublishedV2
 	event.Meta.Type = "EiffelAnnouncementPublishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new AnnouncementPublishedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *AnnouncementPublishedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *AnnouncementPublishedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *AnnouncementPublishedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *AnnouncementPublishedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &AnnouncementPublishedV2{}
 
 type AnnouncementPublishedV2 struct {
 	// Mandatory fields

--- a/EiffelAnnouncementPublishedEventV3.go
+++ b/EiffelAnnouncementPublishedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewAnnouncementPublishedV3() (*AnnouncementPublishedV3, error) {
+func NewAnnouncementPublishedV3(modifiers ...Modifier) (*AnnouncementPublishedV3, error) {
 	var event AnnouncementPublishedV3
 	event.Meta.Type = "EiffelAnnouncementPublishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new AnnouncementPublishedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *AnnouncementPublishedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *AnnouncementPublishedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *AnnouncementPublishedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *AnnouncementPublishedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &AnnouncementPublishedV3{}
 
 type AnnouncementPublishedV3 struct {
 	// Mandatory fields

--- a/EiffelArtifactCreatedEventV1.go
+++ b/EiffelArtifactCreatedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewArtifactCreatedV1() (*ArtifactCreatedV1, error) {
+func NewArtifactCreatedV1(modifiers ...Modifier) (*ArtifactCreatedV1, error) {
 	var event ArtifactCreatedV1
 	event.Meta.Type = "EiffelArtifactCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactCreatedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactCreatedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactCreatedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactCreatedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactCreatedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactCreatedV1{}
 
 type ArtifactCreatedV1 struct {
 	// Mandatory fields

--- a/EiffelArtifactCreatedEventV2.go
+++ b/EiffelArtifactCreatedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewArtifactCreatedV2() (*ArtifactCreatedV2, error) {
+func NewArtifactCreatedV2(modifiers ...Modifier) (*ArtifactCreatedV2, error) {
 	var event ArtifactCreatedV2
 	event.Meta.Type = "EiffelArtifactCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactCreatedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactCreatedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactCreatedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactCreatedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactCreatedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactCreatedV2{}
 
 type ArtifactCreatedV2 struct {
 	// Mandatory fields

--- a/EiffelArtifactCreatedEventV3.go
+++ b/EiffelArtifactCreatedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewArtifactCreatedV3() (*ArtifactCreatedV3, error) {
+func NewArtifactCreatedV3(modifiers ...Modifier) (*ArtifactCreatedV3, error) {
 	var event ArtifactCreatedV3
 	event.Meta.Type = "EiffelArtifactCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactCreatedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactCreatedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactCreatedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactCreatedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactCreatedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactCreatedV3{}
 
 type ArtifactCreatedV3 struct {
 	// Mandatory fields

--- a/EiffelArtifactPublishedEventV2.go
+++ b/EiffelArtifactPublishedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewArtifactPublishedV2() (*ArtifactPublishedV2, error) {
+func NewArtifactPublishedV2(modifiers ...Modifier) (*ArtifactPublishedV2, error) {
 	var event ArtifactPublishedV2
 	event.Meta.Type = "EiffelArtifactPublishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactPublishedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactPublishedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactPublishedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactPublishedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactPublishedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactPublishedV2{}
 
 type ArtifactPublishedV2 struct {
 	// Mandatory fields

--- a/EiffelArtifactPublishedEventV3.go
+++ b/EiffelArtifactPublishedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewArtifactPublishedV3() (*ArtifactPublishedV3, error) {
+func NewArtifactPublishedV3(modifiers ...Modifier) (*ArtifactPublishedV3, error) {
 	var event ArtifactPublishedV3
 	event.Meta.Type = "EiffelArtifactPublishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactPublishedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactPublishedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactPublishedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactPublishedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactPublishedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactPublishedV3{}
 
 type ArtifactPublishedV3 struct {
 	// Mandatory fields

--- a/EiffelArtifactReusedEventV1.go
+++ b/EiffelArtifactReusedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewArtifactReusedV1() (*ArtifactReusedV1, error) {
+func NewArtifactReusedV1(modifiers ...Modifier) (*ArtifactReusedV1, error) {
 	var event ArtifactReusedV1
 	event.Meta.Type = "EiffelArtifactReusedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactReusedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactReusedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactReusedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactReusedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactReusedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactReusedV1{}
 
 type ArtifactReusedV1 struct {
 	// Mandatory fields

--- a/EiffelArtifactReusedEventV2.go
+++ b/EiffelArtifactReusedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewArtifactReusedV2() (*ArtifactReusedV2, error) {
+func NewArtifactReusedV2(modifiers ...Modifier) (*ArtifactReusedV2, error) {
 	var event ArtifactReusedV2
 	event.Meta.Type = "EiffelArtifactReusedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactReusedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactReusedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactReusedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactReusedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactReusedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactReusedV2{}
 
 type ArtifactReusedV2 struct {
 	// Mandatory fields

--- a/EiffelArtifactReusedEventV3.go
+++ b/EiffelArtifactReusedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewArtifactReusedV3() (*ArtifactReusedV3, error) {
+func NewArtifactReusedV3(modifiers ...Modifier) (*ArtifactReusedV3, error) {
 	var event ArtifactReusedV3
 	event.Meta.Type = "EiffelArtifactReusedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ArtifactReusedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ArtifactReusedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ArtifactReusedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ArtifactReusedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ArtifactReusedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ArtifactReusedV3{}
 
 type ArtifactReusedV3 struct {
 	// Mandatory fields

--- a/EiffelCompositionDefinedEventV1.go
+++ b/EiffelCompositionDefinedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewCompositionDefinedV1() (*CompositionDefinedV1, error) {
+func NewCompositionDefinedV1(modifiers ...Modifier) (*CompositionDefinedV1, error) {
 	var event CompositionDefinedV1
 	event.Meta.Type = "EiffelCompositionDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new CompositionDefinedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *CompositionDefinedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *CompositionDefinedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *CompositionDefinedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *CompositionDefinedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &CompositionDefinedV1{}
 
 type CompositionDefinedV1 struct {
 	// Mandatory fields

--- a/EiffelCompositionDefinedEventV2.go
+++ b/EiffelCompositionDefinedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewCompositionDefinedV2() (*CompositionDefinedV2, error) {
+func NewCompositionDefinedV2(modifiers ...Modifier) (*CompositionDefinedV2, error) {
 	var event CompositionDefinedV2
 	event.Meta.Type = "EiffelCompositionDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new CompositionDefinedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *CompositionDefinedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *CompositionDefinedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *CompositionDefinedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *CompositionDefinedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &CompositionDefinedV2{}
 
 type CompositionDefinedV2 struct {
 	// Mandatory fields

--- a/EiffelCompositionDefinedEventV3.go
+++ b/EiffelCompositionDefinedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewCompositionDefinedV3() (*CompositionDefinedV3, error) {
+func NewCompositionDefinedV3(modifiers ...Modifier) (*CompositionDefinedV3, error) {
 	var event CompositionDefinedV3
 	event.Meta.Type = "EiffelCompositionDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new CompositionDefinedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *CompositionDefinedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *CompositionDefinedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *CompositionDefinedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *CompositionDefinedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &CompositionDefinedV3{}
 
 type CompositionDefinedV3 struct {
 	// Mandatory fields

--- a/EiffelConfidenceLevelModifiedEventV1.go
+++ b/EiffelConfidenceLevelModifiedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewConfidenceLevelModifiedV1() (*ConfidenceLevelModifiedV1, error) {
+func NewConfidenceLevelModifiedV1(modifiers ...Modifier) (*ConfidenceLevelModifiedV1, error) {
 	var event ConfidenceLevelModifiedV1
 	event.Meta.Type = "EiffelConfidenceLevelModifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ConfidenceLevelModifiedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ConfidenceLevelModifiedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ConfidenceLevelModifiedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ConfidenceLevelModifiedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ConfidenceLevelModifiedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ConfidenceLevelModifiedV1{}
 
 type ConfidenceLevelModifiedV1 struct {
 	// Mandatory fields

--- a/EiffelConfidenceLevelModifiedEventV2.go
+++ b/EiffelConfidenceLevelModifiedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewConfidenceLevelModifiedV2() (*ConfidenceLevelModifiedV2, error) {
+func NewConfidenceLevelModifiedV2(modifiers ...Modifier) (*ConfidenceLevelModifiedV2, error) {
 	var event ConfidenceLevelModifiedV2
 	event.Meta.Type = "EiffelConfidenceLevelModifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ConfidenceLevelModifiedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ConfidenceLevelModifiedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ConfidenceLevelModifiedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ConfidenceLevelModifiedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ConfidenceLevelModifiedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ConfidenceLevelModifiedV2{}
 
 type ConfidenceLevelModifiedV2 struct {
 	// Mandatory fields

--- a/EiffelConfidenceLevelModifiedEventV3.go
+++ b/EiffelConfidenceLevelModifiedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewConfidenceLevelModifiedV3() (*ConfidenceLevelModifiedV3, error) {
+func NewConfidenceLevelModifiedV3(modifiers ...Modifier) (*ConfidenceLevelModifiedV3, error) {
 	var event ConfidenceLevelModifiedV3
 	event.Meta.Type = "EiffelConfidenceLevelModifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new ConfidenceLevelModifiedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *ConfidenceLevelModifiedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *ConfidenceLevelModifiedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *ConfidenceLevelModifiedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *ConfidenceLevelModifiedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &ConfidenceLevelModifiedV3{}
 
 type ConfidenceLevelModifiedV3 struct {
 	// Mandatory fields

--- a/EiffelEnvironmentDefinedEventV1.go
+++ b/EiffelEnvironmentDefinedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewEnvironmentDefinedV1() (*EnvironmentDefinedV1, error) {
+func NewEnvironmentDefinedV1(modifiers ...Modifier) (*EnvironmentDefinedV1, error) {
 	var event EnvironmentDefinedV1
 	event.Meta.Type = "EiffelEnvironmentDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new EnvironmentDefinedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *EnvironmentDefinedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *EnvironmentDefinedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *EnvironmentDefinedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *EnvironmentDefinedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &EnvironmentDefinedV1{}
 
 type EnvironmentDefinedV1 struct {
 	// Mandatory fields

--- a/EiffelEnvironmentDefinedEventV2.go
+++ b/EiffelEnvironmentDefinedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewEnvironmentDefinedV2() (*EnvironmentDefinedV2, error) {
+func NewEnvironmentDefinedV2(modifiers ...Modifier) (*EnvironmentDefinedV2, error) {
 	var event EnvironmentDefinedV2
 	event.Meta.Type = "EiffelEnvironmentDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new EnvironmentDefinedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *EnvironmentDefinedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *EnvironmentDefinedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *EnvironmentDefinedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *EnvironmentDefinedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &EnvironmentDefinedV2{}
 
 type EnvironmentDefinedV2 struct {
 	// Mandatory fields

--- a/EiffelEnvironmentDefinedEventV3.go
+++ b/EiffelEnvironmentDefinedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewEnvironmentDefinedV3() (*EnvironmentDefinedV3, error) {
+func NewEnvironmentDefinedV3(modifiers ...Modifier) (*EnvironmentDefinedV3, error) {
 	var event EnvironmentDefinedV3
 	event.Meta.Type = "EiffelEnvironmentDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new EnvironmentDefinedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *EnvironmentDefinedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *EnvironmentDefinedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *EnvironmentDefinedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *EnvironmentDefinedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &EnvironmentDefinedV3{}
 
 type EnvironmentDefinedV3 struct {
 	// Mandatory fields

--- a/EiffelFlowContextDefinedEventV1.go
+++ b/EiffelFlowContextDefinedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewFlowContextDefinedV1() (*FlowContextDefinedV1, error) {
+func NewFlowContextDefinedV1(modifiers ...Modifier) (*FlowContextDefinedV1, error) {
 	var event FlowContextDefinedV1
 	event.Meta.Type = "EiffelFlowContextDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new FlowContextDefinedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *FlowContextDefinedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *FlowContextDefinedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *FlowContextDefinedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *FlowContextDefinedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &FlowContextDefinedV1{}
 
 type FlowContextDefinedV1 struct {
 	// Mandatory fields

--- a/EiffelFlowContextDefinedEventV2.go
+++ b/EiffelFlowContextDefinedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewFlowContextDefinedV2() (*FlowContextDefinedV2, error) {
+func NewFlowContextDefinedV2(modifiers ...Modifier) (*FlowContextDefinedV2, error) {
 	var event FlowContextDefinedV2
 	event.Meta.Type = "EiffelFlowContextDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new FlowContextDefinedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *FlowContextDefinedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *FlowContextDefinedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *FlowContextDefinedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *FlowContextDefinedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &FlowContextDefinedV2{}
 
 type FlowContextDefinedV2 struct {
 	// Mandatory fields

--- a/EiffelFlowContextDefinedEventV3.go
+++ b/EiffelFlowContextDefinedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewFlowContextDefinedV3() (*FlowContextDefinedV3, error) {
+func NewFlowContextDefinedV3(modifiers ...Modifier) (*FlowContextDefinedV3, error) {
 	var event FlowContextDefinedV3
 	event.Meta.Type = "EiffelFlowContextDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new FlowContextDefinedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *FlowContextDefinedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *FlowContextDefinedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *FlowContextDefinedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *FlowContextDefinedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &FlowContextDefinedV3{}
 
 type FlowContextDefinedV3 struct {
 	// Mandatory fields

--- a/EiffelIssueDefinedEventV1.go
+++ b/EiffelIssueDefinedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewIssueDefinedV1() (*IssueDefinedV1, error) {
+func NewIssueDefinedV1(modifiers ...Modifier) (*IssueDefinedV1, error) {
 	var event IssueDefinedV1
 	event.Meta.Type = "EiffelIssueDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueDefinedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueDefinedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueDefinedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueDefinedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueDefinedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueDefinedV1{}
 
 type IssueDefinedV1 struct {
 	// Mandatory fields

--- a/EiffelIssueDefinedEventV2.go
+++ b/EiffelIssueDefinedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewIssueDefinedV2() (*IssueDefinedV2, error) {
+func NewIssueDefinedV2(modifiers ...Modifier) (*IssueDefinedV2, error) {
 	var event IssueDefinedV2
 	event.Meta.Type = "EiffelIssueDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueDefinedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueDefinedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueDefinedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueDefinedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueDefinedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueDefinedV2{}
 
 type IssueDefinedV2 struct {
 	// Mandatory fields

--- a/EiffelIssueDefinedEventV3.go
+++ b/EiffelIssueDefinedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewIssueDefinedV3() (*IssueDefinedV3, error) {
+func NewIssueDefinedV3(modifiers ...Modifier) (*IssueDefinedV3, error) {
 	var event IssueDefinedV3
 	event.Meta.Type = "EiffelIssueDefinedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueDefinedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueDefinedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueDefinedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueDefinedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueDefinedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueDefinedV3{}
 
 type IssueDefinedV3 struct {
 	// Mandatory fields

--- a/EiffelIssueVerifiedEventV1.go
+++ b/EiffelIssueVerifiedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewIssueVerifiedV1() (*IssueVerifiedV1, error) {
+func NewIssueVerifiedV1(modifiers ...Modifier) (*IssueVerifiedV1, error) {
 	var event IssueVerifiedV1
 	event.Meta.Type = "EiffelIssueVerifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueVerifiedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueVerifiedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueVerifiedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueVerifiedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueVerifiedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueVerifiedV1{}
 
 type IssueVerifiedV1 struct {
 	// Mandatory fields

--- a/EiffelIssueVerifiedEventV2.go
+++ b/EiffelIssueVerifiedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewIssueVerifiedV2() (*IssueVerifiedV2, error) {
+func NewIssueVerifiedV2(modifiers ...Modifier) (*IssueVerifiedV2, error) {
 	var event IssueVerifiedV2
 	event.Meta.Type = "EiffelIssueVerifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueVerifiedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueVerifiedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueVerifiedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueVerifiedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueVerifiedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueVerifiedV2{}
 
 type IssueVerifiedV2 struct {
 	// Mandatory fields

--- a/EiffelIssueVerifiedEventV3.go
+++ b/EiffelIssueVerifiedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewIssueVerifiedV3() (*IssueVerifiedV3, error) {
+func NewIssueVerifiedV3(modifiers ...Modifier) (*IssueVerifiedV3, error) {
 	var event IssueVerifiedV3
 	event.Meta.Type = "EiffelIssueVerifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueVerifiedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueVerifiedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueVerifiedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueVerifiedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueVerifiedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueVerifiedV3{}
 
 type IssueVerifiedV3 struct {
 	// Mandatory fields

--- a/EiffelIssueVerifiedEventV4.go
+++ b/EiffelIssueVerifiedEventV4.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 4.x.x
 // currently known by this SDK.
-func NewIssueVerifiedV4() (*IssueVerifiedV4, error) {
+func NewIssueVerifiedV4(modifiers ...Modifier) (*IssueVerifiedV4, error) {
 	var event IssueVerifiedV4
 	event.Meta.Type = "EiffelIssueVerifiedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][4].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new IssueVerifiedV4: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *IssueVerifiedV4) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *IssueVerifiedV4) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *IssueVerifiedV4) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *IssueVerifiedV4) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &IssueVerifiedV4{}
 
 type IssueVerifiedV4 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeCreatedEventV1.go
+++ b/EiffelSourceChangeCreatedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewSourceChangeCreatedV1() (*SourceChangeCreatedV1, error) {
+func NewSourceChangeCreatedV1(modifiers ...Modifier) (*SourceChangeCreatedV1, error) {
 	var event SourceChangeCreatedV1
 	event.Meta.Type = "EiffelSourceChangeCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeCreatedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeCreatedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeCreatedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeCreatedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeCreatedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeCreatedV1{}
 
 type SourceChangeCreatedV1 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeCreatedEventV2.go
+++ b/EiffelSourceChangeCreatedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewSourceChangeCreatedV2() (*SourceChangeCreatedV2, error) {
+func NewSourceChangeCreatedV2(modifiers ...Modifier) (*SourceChangeCreatedV2, error) {
 	var event SourceChangeCreatedV2
 	event.Meta.Type = "EiffelSourceChangeCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeCreatedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeCreatedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeCreatedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeCreatedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeCreatedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeCreatedV2{}
 
 type SourceChangeCreatedV2 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeCreatedEventV3.go
+++ b/EiffelSourceChangeCreatedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewSourceChangeCreatedV3() (*SourceChangeCreatedV3, error) {
+func NewSourceChangeCreatedV3(modifiers ...Modifier) (*SourceChangeCreatedV3, error) {
 	var event SourceChangeCreatedV3
 	event.Meta.Type = "EiffelSourceChangeCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeCreatedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeCreatedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeCreatedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeCreatedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeCreatedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeCreatedV3{}
 
 type SourceChangeCreatedV3 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeCreatedEventV4.go
+++ b/EiffelSourceChangeCreatedEventV4.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 4.x.x
 // currently known by this SDK.
-func NewSourceChangeCreatedV4() (*SourceChangeCreatedV4, error) {
+func NewSourceChangeCreatedV4(modifiers ...Modifier) (*SourceChangeCreatedV4, error) {
 	var event SourceChangeCreatedV4
 	event.Meta.Type = "EiffelSourceChangeCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][4].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeCreatedV4: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeCreatedV4) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeCreatedV4) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeCreatedV4) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeCreatedV4) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeCreatedV4{}
 
 type SourceChangeCreatedV4 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeSubmittedEventV1.go
+++ b/EiffelSourceChangeSubmittedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewSourceChangeSubmittedV1() (*SourceChangeSubmittedV1, error) {
+func NewSourceChangeSubmittedV1(modifiers ...Modifier) (*SourceChangeSubmittedV1, error) {
 	var event SourceChangeSubmittedV1
 	event.Meta.Type = "EiffelSourceChangeSubmittedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeSubmittedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeSubmittedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeSubmittedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeSubmittedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeSubmittedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeSubmittedV1{}
 
 type SourceChangeSubmittedV1 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeSubmittedEventV2.go
+++ b/EiffelSourceChangeSubmittedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewSourceChangeSubmittedV2() (*SourceChangeSubmittedV2, error) {
+func NewSourceChangeSubmittedV2(modifiers ...Modifier) (*SourceChangeSubmittedV2, error) {
 	var event SourceChangeSubmittedV2
 	event.Meta.Type = "EiffelSourceChangeSubmittedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeSubmittedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeSubmittedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeSubmittedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeSubmittedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeSubmittedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeSubmittedV2{}
 
 type SourceChangeSubmittedV2 struct {
 	// Mandatory fields

--- a/EiffelSourceChangeSubmittedEventV3.go
+++ b/EiffelSourceChangeSubmittedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewSourceChangeSubmittedV3() (*SourceChangeSubmittedV3, error) {
+func NewSourceChangeSubmittedV3(modifiers ...Modifier) (*SourceChangeSubmittedV3, error) {
 	var event SourceChangeSubmittedV3
 	event.Meta.Type = "EiffelSourceChangeSubmittedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new SourceChangeSubmittedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *SourceChangeSubmittedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *SourceChangeSubmittedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *SourceChangeSubmittedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *SourceChangeSubmittedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &SourceChangeSubmittedV3{}
 
 type SourceChangeSubmittedV3 struct {
 	// Mandatory fields

--- a/EiffelTestCaseCanceledEventV1.go
+++ b/EiffelTestCaseCanceledEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewTestCaseCanceledV1() (*TestCaseCanceledV1, error) {
+func NewTestCaseCanceledV1(modifiers ...Modifier) (*TestCaseCanceledV1, error) {
 	var event TestCaseCanceledV1
 	event.Meta.Type = "EiffelTestCaseCanceledEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseCanceledV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseCanceledV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseCanceledV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseCanceledV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseCanceledV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseCanceledV1{}
 
 type TestCaseCanceledV1 struct {
 	// Mandatory fields

--- a/EiffelTestCaseCanceledEventV2.go
+++ b/EiffelTestCaseCanceledEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewTestCaseCanceledV2() (*TestCaseCanceledV2, error) {
+func NewTestCaseCanceledV2(modifiers ...Modifier) (*TestCaseCanceledV2, error) {
 	var event TestCaseCanceledV2
 	event.Meta.Type = "EiffelTestCaseCanceledEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseCanceledV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseCanceledV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseCanceledV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseCanceledV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseCanceledV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseCanceledV2{}
 
 type TestCaseCanceledV2 struct {
 	// Mandatory fields

--- a/EiffelTestCaseCanceledEventV3.go
+++ b/EiffelTestCaseCanceledEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestCaseCanceledV3() (*TestCaseCanceledV3, error) {
+func NewTestCaseCanceledV3(modifiers ...Modifier) (*TestCaseCanceledV3, error) {
 	var event TestCaseCanceledV3
 	event.Meta.Type = "EiffelTestCaseCanceledEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseCanceledV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseCanceledV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseCanceledV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseCanceledV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseCanceledV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseCanceledV3{}
 
 type TestCaseCanceledV3 struct {
 	// Mandatory fields

--- a/EiffelTestCaseFinishedEventV1.go
+++ b/EiffelTestCaseFinishedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewTestCaseFinishedV1() (*TestCaseFinishedV1, error) {
+func NewTestCaseFinishedV1(modifiers ...Modifier) (*TestCaseFinishedV1, error) {
 	var event TestCaseFinishedV1
 	event.Meta.Type = "EiffelTestCaseFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseFinishedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseFinishedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseFinishedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseFinishedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseFinishedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseFinishedV1{}
 
 type TestCaseFinishedV1 struct {
 	// Mandatory fields

--- a/EiffelTestCaseFinishedEventV2.go
+++ b/EiffelTestCaseFinishedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewTestCaseFinishedV2() (*TestCaseFinishedV2, error) {
+func NewTestCaseFinishedV2(modifiers ...Modifier) (*TestCaseFinishedV2, error) {
 	var event TestCaseFinishedV2
 	event.Meta.Type = "EiffelTestCaseFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseFinishedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseFinishedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseFinishedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseFinishedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseFinishedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseFinishedV2{}
 
 type TestCaseFinishedV2 struct {
 	// Mandatory fields

--- a/EiffelTestCaseFinishedEventV3.go
+++ b/EiffelTestCaseFinishedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestCaseFinishedV3() (*TestCaseFinishedV3, error) {
+func NewTestCaseFinishedV3(modifiers ...Modifier) (*TestCaseFinishedV3, error) {
 	var event TestCaseFinishedV3
 	event.Meta.Type = "EiffelTestCaseFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseFinishedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseFinishedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseFinishedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseFinishedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseFinishedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseFinishedV3{}
 
 type TestCaseFinishedV3 struct {
 	// Mandatory fields

--- a/EiffelTestCaseStartedEventV2.go
+++ b/EiffelTestCaseStartedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewTestCaseStartedV2() (*TestCaseStartedV2, error) {
+func NewTestCaseStartedV2(modifiers ...Modifier) (*TestCaseStartedV2, error) {
 	var event TestCaseStartedV2
 	event.Meta.Type = "EiffelTestCaseStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseStartedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseStartedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseStartedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseStartedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseStartedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseStartedV2{}
 
 type TestCaseStartedV2 struct {
 	// Mandatory fields

--- a/EiffelTestCaseStartedEventV3.go
+++ b/EiffelTestCaseStartedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestCaseStartedV3() (*TestCaseStartedV3, error) {
+func NewTestCaseStartedV3(modifiers ...Modifier) (*TestCaseStartedV3, error) {
 	var event TestCaseStartedV3
 	event.Meta.Type = "EiffelTestCaseStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseStartedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseStartedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseStartedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseStartedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseStartedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseStartedV3{}
 
 type TestCaseStartedV3 struct {
 	// Mandatory fields

--- a/EiffelTestCaseTriggeredEventV1.go
+++ b/EiffelTestCaseTriggeredEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewTestCaseTriggeredV1() (*TestCaseTriggeredV1, error) {
+func NewTestCaseTriggeredV1(modifiers ...Modifier) (*TestCaseTriggeredV1, error) {
 	var event TestCaseTriggeredV1
 	event.Meta.Type = "EiffelTestCaseTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseTriggeredV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseTriggeredV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseTriggeredV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseTriggeredV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseTriggeredV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseTriggeredV1{}
 
 type TestCaseTriggeredV1 struct {
 	// Mandatory fields

--- a/EiffelTestCaseTriggeredEventV2.go
+++ b/EiffelTestCaseTriggeredEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewTestCaseTriggeredV2() (*TestCaseTriggeredV2, error) {
+func NewTestCaseTriggeredV2(modifiers ...Modifier) (*TestCaseTriggeredV2, error) {
 	var event TestCaseTriggeredV2
 	event.Meta.Type = "EiffelTestCaseTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseTriggeredV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseTriggeredV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseTriggeredV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseTriggeredV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseTriggeredV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseTriggeredV2{}
 
 type TestCaseTriggeredV2 struct {
 	// Mandatory fields

--- a/EiffelTestCaseTriggeredEventV3.go
+++ b/EiffelTestCaseTriggeredEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestCaseTriggeredV3() (*TestCaseTriggeredV3, error) {
+func NewTestCaseTriggeredV3(modifiers ...Modifier) (*TestCaseTriggeredV3, error) {
 	var event TestCaseTriggeredV3
 	event.Meta.Type = "EiffelTestCaseTriggeredEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestCaseTriggeredV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestCaseTriggeredV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestCaseTriggeredV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestCaseTriggeredV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestCaseTriggeredV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestCaseTriggeredV3{}
 
 type TestCaseTriggeredV3 struct {
 	// Mandatory fields

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewTestExecutionRecipeCollectionCreatedV1() (*TestExecutionRecipeCollectionCreatedV1, error) {
+func NewTestExecutionRecipeCollectionCreatedV1(modifiers ...Modifier) (*TestExecutionRecipeCollectionCreatedV1, error) {
 	var event TestExecutionRecipeCollectionCreatedV1
 	event.Meta.Type = "EiffelTestExecutionRecipeCollectionCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestExecutionRecipeCollectionCreatedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestExecutionRecipeCollectionCreatedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestExecutionRecipeCollectionCreatedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestExecutionRecipeCollectionCreatedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestExecutionRecipeCollectionCreatedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV1{}
 
 type TestExecutionRecipeCollectionCreatedV1 struct {
 	// Mandatory fields

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewTestExecutionRecipeCollectionCreatedV2() (*TestExecutionRecipeCollectionCreatedV2, error) {
+func NewTestExecutionRecipeCollectionCreatedV2(modifiers ...Modifier) (*TestExecutionRecipeCollectionCreatedV2, error) {
 	var event TestExecutionRecipeCollectionCreatedV2
 	event.Meta.Type = "EiffelTestExecutionRecipeCollectionCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestExecutionRecipeCollectionCreatedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestExecutionRecipeCollectionCreatedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestExecutionRecipeCollectionCreatedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestExecutionRecipeCollectionCreatedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestExecutionRecipeCollectionCreatedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV2{}
 
 type TestExecutionRecipeCollectionCreatedV2 struct {
 	// Mandatory fields

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestExecutionRecipeCollectionCreatedV3() (*TestExecutionRecipeCollectionCreatedV3, error) {
+func NewTestExecutionRecipeCollectionCreatedV3(modifiers ...Modifier) (*TestExecutionRecipeCollectionCreatedV3, error) {
 	var event TestExecutionRecipeCollectionCreatedV3
 	event.Meta.Type = "EiffelTestExecutionRecipeCollectionCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestExecutionRecipeCollectionCreatedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestExecutionRecipeCollectionCreatedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestExecutionRecipeCollectionCreatedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestExecutionRecipeCollectionCreatedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestExecutionRecipeCollectionCreatedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV3{}
 
 type TestExecutionRecipeCollectionCreatedV3 struct {
 	// Mandatory fields

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 4.x.x
 // currently known by this SDK.
-func NewTestExecutionRecipeCollectionCreatedV4() (*TestExecutionRecipeCollectionCreatedV4, error) {
+func NewTestExecutionRecipeCollectionCreatedV4(modifiers ...Modifier) (*TestExecutionRecipeCollectionCreatedV4, error) {
 	var event TestExecutionRecipeCollectionCreatedV4
 	event.Meta.Type = "EiffelTestExecutionRecipeCollectionCreatedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][4].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestExecutionRecipeCollectionCreatedV4: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestExecutionRecipeCollectionCreatedV4) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestExecutionRecipeCollectionCreatedV4) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestExecutionRecipeCollectionCreatedV4) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestExecutionRecipeCollectionCreatedV4) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV4{}
 
 type TestExecutionRecipeCollectionCreatedV4 struct {
 	// Mandatory fields

--- a/EiffelTestSuiteFinishedEventV1.go
+++ b/EiffelTestSuiteFinishedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewTestSuiteFinishedV1() (*TestSuiteFinishedV1, error) {
+func NewTestSuiteFinishedV1(modifiers ...Modifier) (*TestSuiteFinishedV1, error) {
 	var event TestSuiteFinishedV1
 	event.Meta.Type = "EiffelTestSuiteFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestSuiteFinishedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestSuiteFinishedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestSuiteFinishedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestSuiteFinishedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestSuiteFinishedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestSuiteFinishedV1{}
 
 type TestSuiteFinishedV1 struct {
 	// Mandatory fields

--- a/EiffelTestSuiteFinishedEventV3.go
+++ b/EiffelTestSuiteFinishedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestSuiteFinishedV3() (*TestSuiteFinishedV3, error) {
+func NewTestSuiteFinishedV3(modifiers ...Modifier) (*TestSuiteFinishedV3, error) {
 	var event TestSuiteFinishedV3
 	event.Meta.Type = "EiffelTestSuiteFinishedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestSuiteFinishedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestSuiteFinishedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestSuiteFinishedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestSuiteFinishedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestSuiteFinishedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestSuiteFinishedV3{}
 
 type TestSuiteFinishedV3 struct {
 	// Mandatory fields

--- a/EiffelTestSuiteStartedEventV1.go
+++ b/EiffelTestSuiteStartedEventV1.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 1.x.x
 // currently known by this SDK.
-func NewTestSuiteStartedV1() (*TestSuiteStartedV1, error) {
+func NewTestSuiteStartedV1(modifiers ...Modifier) (*TestSuiteStartedV1, error) {
 	var event TestSuiteStartedV1
 	event.Meta.Type = "EiffelTestSuiteStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][1].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestSuiteStartedV1: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestSuiteStartedV1) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestSuiteStartedV1) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestSuiteStartedV1) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestSuiteStartedV1) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestSuiteStartedV1{}
 
 type TestSuiteStartedV1 struct {
 	// Mandatory fields

--- a/EiffelTestSuiteStartedEventV2.go
+++ b/EiffelTestSuiteStartedEventV2.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 2.x.x
 // currently known by this SDK.
-func NewTestSuiteStartedV2() (*TestSuiteStartedV2, error) {
+func NewTestSuiteStartedV2(modifiers ...Modifier) (*TestSuiteStartedV2, error) {
 	var event TestSuiteStartedV2
 	event.Meta.Type = "EiffelTestSuiteStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][2].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestSuiteStartedV2: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestSuiteStartedV2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestSuiteStartedV2) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestSuiteStartedV2) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestSuiteStartedV2) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestSuiteStartedV2{}
 
 type TestSuiteStartedV2 struct {
 	// Mandatory fields

--- a/EiffelTestSuiteStartedEventV3.go
+++ b/EiffelTestSuiteStartedEventV3.go
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent 3.x.x
 // currently known by this SDK.
-func NewTestSuiteStartedV3() (*TestSuiteStartedV3, error) {
+func NewTestSuiteStartedV3(modifiers ...Modifier) (*TestSuiteStartedV3, error) {
 	var event TestSuiteStartedV3
 	event.Meta.Type = "EiffelTestSuiteStartedEvent"
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][3].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new TestSuiteStartedV3: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *TestSuiteStartedV3) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *TestSuiteStartedV3) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *TestSuiteStartedV3) String() string {
 	b, err := e.MarshalJSON()
@@ -77,6 +88,8 @@ func (e *TestSuiteStartedV3) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &TestSuiteStartedV3{}
 
 type TestSuiteStartedV3 struct {
 	// Mandatory fields

--- a/fieldsetter.go
+++ b/fieldsetter.go
@@ -1,0 +1,81 @@
+package eiffelevents
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// FieldSetter sets struct field by name using the usual toplevelfield.subfield notation.
+// Fields should be expressed with their JSON names, i.e. based on the "json" tag.
+type FieldSetter interface {
+	SetField(fieldName string, value interface{}) error
+}
+
+// setField sets the value of a struct field whose path is expressed
+// with dot notation using the field names in the "json" tag. The reflect.Value
+// passed as the target must be a pointer to a struct.
+func setField(target reflect.Value, fieldName string, value interface{}) error {
+	if target.Kind() != reflect.Ptr {
+		return errors.New("target value is not a pointer")
+	}
+	elemVal := target.Elem()
+	if elemVal.Kind() != reflect.Struct {
+		return fmt.Errorf("the target value must point to a struct but pointed to a %s", elemVal.Kind())
+	}
+
+	// Recurse if there's a dot in the field name, otherwise try to set that field.
+	dotIndex := strings.Index(fieldName, ".")
+	if dotIndex == 0 {
+		return fmt.Errorf("invalid field name: %q", fieldName)
+	}
+	if dotIndex > 0 {
+		firstLevelFieldName := fieldName[0:dotIndex]
+		remainderFieldName := fieldName[dotIndex+1:]
+
+		// Locate the struct to recurse into
+		field, err := getJSONField(elemVal, firstLevelFieldName)
+		if err != nil {
+			return err
+		}
+		if !field.CanAddr() {
+			return fmt.Errorf("struct field %q is not addressable", firstLevelFieldName)
+		}
+		return setField(field.Addr(), remainderFieldName, value)
+	} else {
+		// Locate the field to set
+		field, err := getJSONField(elemVal, fieldName)
+		if err != nil {
+			return err
+		}
+		if !field.CanSet() {
+			return fmt.Errorf("struct field %q cannot be set", fieldName)
+		}
+		field.Set(reflect.ValueOf(value))
+	}
+
+	return nil
+}
+
+// getJSONField returns the value of a struct field that has the given JSON name in the "json" tag.
+func getJSONField(structVal reflect.Value, fieldName string) (reflect.Value, error) {
+	structType := structVal.Type()
+	for i := 0; i < structType.NumField(); i++ {
+		jsonField := structType.Field(i).Tag.Get("json")
+		if jsonField == "" || jsonField == "-" {
+			continue
+		}
+
+		// Trim any additional options from the end,
+		// i.e. turn "fieldname,omitempty" into plain "fieldname".
+		if commaIndex := strings.Index(jsonField, ","); commaIndex != -1 {
+			jsonField = jsonField[0:commaIndex]
+		}
+
+		if jsonField == fieldName {
+			return structVal.Field(i), nil
+		}
+	}
+	return reflect.Value{}, fmt.Errorf("the struct did not contain a field with the JSON name %q", fieldName)
+}

--- a/fieldsetter.go
+++ b/fieldsetter.go
@@ -1,3 +1,19 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package eiffelevents
 
 import (

--- a/fieldsetter_test.go
+++ b/fieldsetter_test.go
@@ -1,0 +1,91 @@
+package eiffelevents
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type setFieldLevel1TestStruct struct {
+	Level1String string                   `json:"level_1_string"`
+	Level1Int    int                      `json:"level_1_int"`
+	Level2       setFieldLevel2TestStruct `json:"level_2"`
+}
+
+type setFieldLevel2TestStruct struct {
+	Level2String string `json:"level_2_string"`
+}
+
+func TestSetField(t *testing.T) {
+	testcases := []struct {
+		name        string
+		input       setFieldLevel1TestStruct
+		field       string
+		value       interface{}
+		expected    setFieldLevel1TestStruct
+		expectedErr string
+	}{
+		{
+			name:  "Set first level string field",
+			input: setFieldLevel1TestStruct{},
+			field: "level_1_string",
+			value: "new value",
+			expected: setFieldLevel1TestStruct{
+				Level1String: "new value",
+			},
+		},
+		{
+			name:  "Set first level int field",
+			input: setFieldLevel1TestStruct{},
+			field: "level_1_int",
+			value: 123,
+			expected: setFieldLevel1TestStruct{
+				Level1Int: 123,
+			},
+		},
+		{
+			name:        "Setting non-existent field fails",
+			input:       setFieldLevel1TestStruct{},
+			field:       "ThisFieldDoesNotExist",
+			value:       "any value",
+			expected:    setFieldLevel1TestStruct{},
+			expectedErr: "struct did not contain a field with the JSON name",
+		},
+		{
+			name:  "Set first level struct field",
+			input: setFieldLevel1TestStruct{},
+			field: "level_2",
+			value: setFieldLevel2TestStruct{
+				Level2String: "new value",
+			},
+			expected: setFieldLevel1TestStruct{
+				Level2: setFieldLevel2TestStruct{
+					Level2String: "new value",
+				},
+			},
+		},
+		{
+			name:  "Set second level string field",
+			input: setFieldLevel1TestStruct{},
+			field: "level_2.level_2_string",
+			value: "new value",
+			expected: setFieldLevel1TestStruct{
+				Level2: setFieldLevel2TestStruct{
+					Level2String: "new value",
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := setField(reflect.ValueOf(&tc.input), tc.field, tc.value)
+			if tc.expectedErr != "" {
+				assert.Contains(t, err.Error(), tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expected, tc.input)
+		})
+	}
+}

--- a/fieldsetter_test.go
+++ b/fieldsetter_test.go
@@ -1,3 +1,19 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package eiffelevents
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/Showmax/go-fqdn v1.0.0
 	github.com/clarketm/json v1.17.1
 	github.com/gertd/go-pluralize v0.1.7
 	github.com/google/renameio v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
+github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/clarketm/json v1.17.1 h1:U1IxjqJkJ7bRK4L6dyphmoO840P6bdhPdbbLySourqI=
 github.com/clarketm/json v1.17.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/internal/cmd/eventgen/templates/eventfile.tmpl
+++ b/internal/cmd/eventgen/templates/eventfile.tmpl
@@ -19,6 +19,8 @@
 package eiffelevents
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/clarketm/json"
@@ -30,12 +32,17 @@ import (
 // The returned struct has all required meta members populated.
 // The event version is set to the most recent {{.MajorVersion}}.x.x
 // currently known by this SDK.
-func New{{.StructName}}() (*{{.StructName}}, error) {
+func New{{.StructName}}(modifiers ...Modifier) (*{{.StructName}}, error) {
 	var event {{.StructName}}
 	event.Meta.Type = {{ printf "%q" .EventType }}
 	event.Meta.ID = uuid.NewString()
 	event.Meta.Version = eventTypeTable[event.Meta.Type][{{.MajorVersion}}].latestVersion
 	event.Meta.Time = time.Now().UnixMilli()
+	for _, modifier := range modifiers {
+		if err := modifier(&event); err != nil {
+			return nil, fmt.Errorf("error applying modifier to new {{.StructName}}: %w", err)
+		}
+	}
 	return &event, nil
 }
 
@@ -66,6 +73,10 @@ func (e *{{.StructName}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s)
 }
 
+func (e *{{.StructName}}) SetField(fieldName string, value interface{}) error {
+	return setField(reflect.ValueOf(e), fieldName, value)
+}
+
 // String returns the JSON encoding of the event.
 func (e *{{.StructName}}) String() string {
 	b, err := e.MarshalJSON()
@@ -77,3 +88,5 @@ func (e *{{.StructName}}) String() string {
 	}
 	return string(b)
 }
+
+var _ FieldSetter = &{{.StructName}}{}

--- a/modifiers.go
+++ b/modifiers.go
@@ -1,0 +1,68 @@
+package eiffelevents
+
+import (
+	"fmt"
+
+	"github.com/Showmax/go-fqdn"
+)
+
+// Modifier defines a kind of function that modifies an untyped Eiffel event.
+// It can be passed to factory functions to adorn the newly created event with
+// additional fields. The main use case is generic field changes that should
+// apply to all events emitted from an application, e.g. the setting of
+// meta.source.domainId.
+//
+// Using modifiers together with a factory function allows creation of new
+// factory functions that include the modifiers. Those factory function can
+// be passed to other parts of the application to reduce duplication.
+type Modifier func(fieldSetter FieldSetter) error
+
+// WithAutoSourceHost attempts to figure out the FQDN of the current host and
+// stores it in the meta.source.host field.
+// WithVersion sets the meta.version field of a newly created event.
+func WithAutoSourceHost() Modifier {
+	return func(fieldSetter FieldSetter) error {
+		hostname, err := fqdn.FqdnHostname()
+		if err != nil {
+			return fmt.Errorf("error determining the local hostname to store in meta.source.host: %w", err)
+		}
+		return fieldSetter.SetField("meta.source.host", hostname)
+	}
+}
+
+// WithSourceDomainID sets the meta.source.domainId field of a newly created event.
+func WithSourceDomainID(domainID string) Modifier {
+	return func(fieldSetter FieldSetter) error {
+		return fieldSetter.SetField("meta.source.domainId", domainID)
+	}
+}
+
+// WithSourceHost sets the meta.source.host field of a newly created event.
+func WithSourceHost(hostname string) Modifier {
+	return func(fieldSetter FieldSetter) error {
+		return fieldSetter.SetField("meta.source.host", hostname)
+	}
+}
+
+// WithSourceName sets the meta.source.name field of a newly created event.
+func WithSourceName(name string) Modifier {
+	return func(fieldSetter FieldSetter) error {
+		return fieldSetter.SetField("meta.source.name", name)
+	}
+}
+
+// WithSourceURI sets the meta.source.uri field of a newly created event.
+func WithSourceURI(uri string) Modifier {
+	return func(fieldSetter FieldSetter) error {
+		return fieldSetter.SetField("meta.source.uri", uri)
+	}
+}
+
+// WithVersion sets the meta.version field of a newly created event.
+// It's typically used to select a different minor or patch version than
+// what the default factory function does.
+func WithVersion(version string) Modifier {
+	return func(fieldSetter FieldSetter) error {
+		return fieldSetter.SetField("meta.version", version)
+	}
+}

--- a/modifiers.go
+++ b/modifiers.go
@@ -1,3 +1,19 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package eiffelevents
 
 import (

--- a/modifiers_test.go
+++ b/modifiers_test.go
@@ -1,3 +1,19 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package eiffelevents
 
 import (

--- a/modifiers_test.go
+++ b/modifiers_test.go
@@ -1,0 +1,58 @@
+package eiffelevents
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleModifier() {
+	// Define a factory function that encapsulates a WithDomainID modifier
+	compositionFactory := func() (*CompositionDefinedV3, error) {
+		return NewCompositionDefinedV3(WithSourceDomainID("example.com"))
+	}
+
+	// Use the newly defined factory to create a customized new event
+	myComposition, _ := compositionFactory()
+	fmt.Println(myComposition.Meta.Source.DomainID)
+
+	// Output: example.com
+}
+
+func TestWithSourceDomainID(t *testing.T) {
+	event, err := NewCompositionDefinedV3(WithSourceDomainID("example.com"))
+	assert.NoError(t, err)
+	assert.Equal(t, "example.com", event.Meta.Source.DomainID)
+}
+
+func TestWithSourceHost(t *testing.T) {
+	event, err := NewCompositionDefinedV3(WithSourceHost("hostname.example.com"))
+	assert.NoError(t, err)
+	assert.Equal(t, "hostname.example.com", event.Meta.Source.Host)
+}
+
+func TestWithSourceName(t *testing.T) {
+	event, err := NewCompositionDefinedV3(WithSourceName("My Application"))
+	assert.NoError(t, err)
+	assert.Equal(t, "My Application", event.Meta.Source.Name)
+}
+
+func TestWithSourceURI(t *testing.T) {
+	event, err := NewCompositionDefinedV3(WithSourceURI("http://www.example.com"))
+	assert.NoError(t, err)
+	assert.Equal(t, "http://www.example.com", event.Meta.Source.URI)
+}
+
+func TestWithVersion(t *testing.T) {
+	newestEventVersion, err := NewCompositionDefinedV3()
+	assert.NoError(t, err)
+	customEventVersion, err := NewCompositionDefinedV3(WithVersion("3.1.0"))
+	assert.NoError(t, err)
+
+	// Make sure we're not accidentally getting a pass because the default
+	// version happens to coincide with the one we're request (which shouldn't
+	// happen unless there's a bug elsewhere).
+	assert.NotEqual(t, "3.1.0", newestEventVersion.Meta.Version)
+	assert.Equal(t, "3.1.0", customEventVersion.Meta.Version)
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #3

### Description of the Change
We introduce the event modifier as a function that can be passed (possibly with other modifiers) to an event factory and will be called on the newly created event. This can be used to extend the default population of fields with e.g. meta.source.host and meta.source.domainId.

### Alternate Designs
Considered generating additional event type methods for setting various fields so that a modifier could call methods in that interface instead. However, unless we make that interface very large there's a risk that a modifier would want to make changes to fields not covered by the interface.

### Benefits
Makes it easier to apply custom initializations for events of all kinds of types without having to implement 

### Possible Drawbacks
The FieldSetter interface and its SetField method relies on reflection to perform the field assignments, which isn't beautiful nor performant.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
