### PR TITLE
Make the links slice a type of its own with helpers methods

### DIFF
--- a/EiffelActivityCanceledEventV1.go
+++ b/EiffelActivityCanceledEventV1.go
@@ -90,12 +90,38 @@ func (e *ActivityCanceledV1) String() string {
 }
 
 var _ FieldSetter = &ActivityCanceledV1{}
+var _ MetaTeller = &ActivityCanceledV1{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityCanceledV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityCanceledV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityCanceledV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityCanceledV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityCanceledV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityCanceledV1 struct {
 	// Mandatory fields
-	Data  ActCV1Data   `json:"data"`
-	Links []ActCV1Link `json:"links"`
-	Meta  ActCV1Meta   `json:"meta"`
+	Data  ActCV1Data  `json:"data"`
+	Links ActCV1Links `json:"links"`
+	Meta  ActCV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -116,6 +142,20 @@ type ActCV1DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// ActCV1Links represents a slice of ActCV1Link values with helper methods
+// for adding new links.
+type ActCV1Links []ActCV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActCV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActCV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActCV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActCV1Link{Target: target, Type: linkType})
 }
 
 type ActCV1Link struct {

--- a/EiffelActivityCanceledEventV2.go
+++ b/EiffelActivityCanceledEventV2.go
@@ -90,12 +90,38 @@ func (e *ActivityCanceledV2) String() string {
 }
 
 var _ FieldSetter = &ActivityCanceledV2{}
+var _ MetaTeller = &ActivityCanceledV2{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityCanceledV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityCanceledV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityCanceledV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityCanceledV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityCanceledV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityCanceledV2 struct {
 	// Mandatory fields
-	Data  ActCV2Data   `json:"data"`
-	Links []ActCV2Link `json:"links"`
-	Meta  ActCV2Meta   `json:"meta"`
+	Data  ActCV2Data  `json:"data"`
+	Links ActCV2Links `json:"links"`
+	Meta  ActCV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -116,6 +142,20 @@ type ActCV2DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// ActCV2Links represents a slice of ActCV2Link values with helper methods
+// for adding new links.
+type ActCV2Links []ActCV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActCV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActCV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActCV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActCV2Link{Target: target, Type: linkType})
 }
 
 type ActCV2Link struct {

--- a/EiffelActivityCanceledEventV3.go
+++ b/EiffelActivityCanceledEventV3.go
@@ -90,12 +90,38 @@ func (e *ActivityCanceledV3) String() string {
 }
 
 var _ FieldSetter = &ActivityCanceledV3{}
+var _ MetaTeller = &ActivityCanceledV3{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityCanceledV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityCanceledV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityCanceledV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityCanceledV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityCanceledV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityCanceledV3 struct {
 	// Mandatory fields
-	Data  ActCV3Data   `json:"data"`
-	Links []ActCV3Link `json:"links"`
-	Meta  ActCV3Meta   `json:"meta"`
+	Data  ActCV3Data  `json:"data"`
+	Links ActCV3Links `json:"links"`
+	Meta  ActCV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -116,6 +142,20 @@ type ActCV3DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// ActCV3Links represents a slice of ActCV3Link values with helper methods
+// for adding new links.
+type ActCV3Links []ActCV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActCV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActCV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActCV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActCV3Link{Target: target, Type: linkType})
 }
 
 type ActCV3Link struct {

--- a/EiffelActivityFinishedEventV1.go
+++ b/EiffelActivityFinishedEventV1.go
@@ -90,12 +90,38 @@ func (e *ActivityFinishedV1) String() string {
 }
 
 var _ FieldSetter = &ActivityFinishedV1{}
+var _ MetaTeller = &ActivityFinishedV1{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityFinishedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityFinishedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityFinishedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityFinishedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityFinishedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityFinishedV1 struct {
 	// Mandatory fields
-	Data  ActFV1Data   `json:"data"`
-	Links []ActFV1Link `json:"links"`
-	Meta  ActFV1Meta   `json:"meta"`
+	Data  ActFV1Data  `json:"data"`
+	Links ActFV1Links `json:"links"`
+	Meta  ActFV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -145,6 +171,20 @@ type ActFV1DataPersistentLog struct {
 
 	// Optional fields
 
+}
+
+// ActFV1Links represents a slice of ActFV1Link values with helper methods
+// for adding new links.
+type ActFV1Links []ActFV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActFV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActFV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActFV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActFV1Link{Target: target, Type: linkType})
 }
 
 type ActFV1Link struct {

--- a/EiffelActivityFinishedEventV2.go
+++ b/EiffelActivityFinishedEventV2.go
@@ -90,12 +90,38 @@ func (e *ActivityFinishedV2) String() string {
 }
 
 var _ FieldSetter = &ActivityFinishedV2{}
+var _ MetaTeller = &ActivityFinishedV2{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityFinishedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityFinishedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityFinishedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityFinishedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityFinishedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityFinishedV2 struct {
 	// Mandatory fields
-	Data  ActFV2Data   `json:"data"`
-	Links []ActFV2Link `json:"links"`
-	Meta  ActFV2Meta   `json:"meta"`
+	Data  ActFV2Data  `json:"data"`
+	Links ActFV2Links `json:"links"`
+	Meta  ActFV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -145,6 +171,20 @@ type ActFV2DataPersistentLog struct {
 
 	// Optional fields
 
+}
+
+// ActFV2Links represents a slice of ActFV2Link values with helper methods
+// for adding new links.
+type ActFV2Links []ActFV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActFV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActFV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActFV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActFV2Link{Target: target, Type: linkType})
 }
 
 type ActFV2Link struct {

--- a/EiffelActivityFinishedEventV3.go
+++ b/EiffelActivityFinishedEventV3.go
@@ -90,12 +90,38 @@ func (e *ActivityFinishedV3) String() string {
 }
 
 var _ FieldSetter = &ActivityFinishedV3{}
+var _ MetaTeller = &ActivityFinishedV3{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityFinishedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityFinishedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityFinishedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityFinishedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityFinishedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityFinishedV3 struct {
 	// Mandatory fields
-	Data  ActFV3Data   `json:"data"`
-	Links []ActFV3Link `json:"links"`
-	Meta  ActFV3Meta   `json:"meta"`
+	Data  ActFV3Data  `json:"data"`
+	Links ActFV3Links `json:"links"`
+	Meta  ActFV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -146,6 +172,20 @@ type ActFV3DataPersistentLog struct {
 	// Optional fields
 	MediaType string   `json:"mediaType,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
+}
+
+// ActFV3Links represents a slice of ActFV3Link values with helper methods
+// for adding new links.
+type ActFV3Links []ActFV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActFV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActFV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActFV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActFV3Link{Target: target, Type: linkType})
 }
 
 type ActFV3Link struct {

--- a/EiffelActivityStartedEventV1.go
+++ b/EiffelActivityStartedEventV1.go
@@ -90,12 +90,38 @@ func (e *ActivityStartedV1) String() string {
 }
 
 var _ FieldSetter = &ActivityStartedV1{}
+var _ MetaTeller = &ActivityStartedV1{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityStartedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityStartedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityStartedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityStartedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityStartedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityStartedV1 struct {
 	// Mandatory fields
-	Data  ActSV1Data   `json:"data"`
-	Links []ActSV1Link `json:"links"`
-	Meta  ActSV1Meta   `json:"meta"`
+	Data  ActSV1Data  `json:"data"`
+	Links ActSV1Links `json:"links"`
+	Meta  ActSV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -126,6 +152,20 @@ type ActSV1DataLiveLog struct {
 
 	// Optional fields
 
+}
+
+// ActSV1Links represents a slice of ActSV1Link values with helper methods
+// for adding new links.
+type ActSV1Links []ActSV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActSV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActSV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActSV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActSV1Link{Target: target, Type: linkType})
 }
 
 type ActSV1Link struct {

--- a/EiffelActivityStartedEventV2.go
+++ b/EiffelActivityStartedEventV2.go
@@ -90,12 +90,38 @@ func (e *ActivityStartedV2) String() string {
 }
 
 var _ FieldSetter = &ActivityStartedV2{}
+var _ MetaTeller = &ActivityStartedV2{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityStartedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityStartedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityStartedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityStartedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityStartedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityStartedV2 struct {
 	// Mandatory fields
-	Data  ActSV2Data   `json:"data"`
-	Links []ActSV2Link `json:"links"`
-	Meta  ActSV2Meta   `json:"meta"`
+	Data  ActSV2Data  `json:"data"`
+	Links ActSV2Links `json:"links"`
+	Meta  ActSV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -126,6 +152,20 @@ type ActSV2DataLiveLog struct {
 
 	// Optional fields
 
+}
+
+// ActSV2Links represents a slice of ActSV2Link values with helper methods
+// for adding new links.
+type ActSV2Links []ActSV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActSV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActSV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActSV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActSV2Link{Target: target, Type: linkType})
 }
 
 type ActSV2Link struct {

--- a/EiffelActivityStartedEventV3.go
+++ b/EiffelActivityStartedEventV3.go
@@ -90,12 +90,38 @@ func (e *ActivityStartedV3) String() string {
 }
 
 var _ FieldSetter = &ActivityStartedV3{}
+var _ MetaTeller = &ActivityStartedV3{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityStartedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityStartedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityStartedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityStartedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityStartedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityStartedV3 struct {
 	// Mandatory fields
-	Data  ActSV3Data   `json:"data"`
-	Links []ActSV3Link `json:"links"`
-	Meta  ActSV3Meta   `json:"meta"`
+	Data  ActSV3Data  `json:"data"`
+	Links ActSV3Links `json:"links"`
+	Meta  ActSV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -126,6 +152,20 @@ type ActSV3DataLiveLog struct {
 
 	// Optional fields
 
+}
+
+// ActSV3Links represents a slice of ActSV3Link values with helper methods
+// for adding new links.
+type ActSV3Links []ActSV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActSV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActSV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActSV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActSV3Link{Target: target, Type: linkType})
 }
 
 type ActSV3Link struct {

--- a/EiffelActivityStartedEventV4.go
+++ b/EiffelActivityStartedEventV4.go
@@ -90,12 +90,38 @@ func (e *ActivityStartedV4) String() string {
 }
 
 var _ FieldSetter = &ActivityStartedV4{}
+var _ MetaTeller = &ActivityStartedV4{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityStartedV4) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityStartedV4) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityStartedV4) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityStartedV4) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityStartedV4) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityStartedV4 struct {
 	// Mandatory fields
-	Data  ActSV4Data   `json:"data"`
-	Links []ActSV4Link `json:"links"`
-	Meta  ActSV4Meta   `json:"meta"`
+	Data  ActSV4Data  `json:"data"`
+	Links ActSV4Links `json:"links"`
+	Meta  ActSV4Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -127,6 +153,20 @@ type ActSV4DataLiveLog struct {
 	// Optional fields
 	MediaType string   `json:"mediaType,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
+}
+
+// ActSV4Links represents a slice of ActSV4Link values with helper methods
+// for adding new links.
+type ActSV4Links []ActSV4Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActSV4Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActSV4Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActSV4Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActSV4Link{Target: target, Type: linkType})
 }
 
 type ActSV4Link struct {

--- a/EiffelActivityTriggeredEventV1.go
+++ b/EiffelActivityTriggeredEventV1.go
@@ -90,12 +90,38 @@ func (e *ActivityTriggeredV1) String() string {
 }
 
 var _ FieldSetter = &ActivityTriggeredV1{}
+var _ MetaTeller = &ActivityTriggeredV1{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityTriggeredV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityTriggeredV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityTriggeredV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityTriggeredV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityTriggeredV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityTriggeredV1 struct {
 	// Mandatory fields
-	Data  ActTV1Data   `json:"data"`
-	Links []ActTV1Link `json:"links"`
-	Meta  ActTV1Meta   `json:"meta"`
+	Data  ActTV1Data  `json:"data"`
+	Links ActTV1Links `json:"links"`
+	Meta  ActTV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -147,6 +173,20 @@ const (
 	ActTV1DataTriggerType_Timer        ActTV1DataTriggerType = "TIMER"
 	ActTV1DataTriggerType_Other        ActTV1DataTriggerType = "OTHER"
 )
+
+// ActTV1Links represents a slice of ActTV1Link values with helper methods
+// for adding new links.
+type ActTV1Links []ActTV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActTV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActTV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActTV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActTV1Link{Target: target, Type: linkType})
+}
 
 type ActTV1Link struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV2.go
+++ b/EiffelActivityTriggeredEventV2.go
@@ -90,12 +90,38 @@ func (e *ActivityTriggeredV2) String() string {
 }
 
 var _ FieldSetter = &ActivityTriggeredV2{}
+var _ MetaTeller = &ActivityTriggeredV2{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityTriggeredV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityTriggeredV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityTriggeredV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityTriggeredV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityTriggeredV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityTriggeredV2 struct {
 	// Mandatory fields
-	Data  ActTV2Data   `json:"data"`
-	Links []ActTV2Link `json:"links"`
-	Meta  ActTV2Meta   `json:"meta"`
+	Data  ActTV2Data  `json:"data"`
+	Links ActTV2Links `json:"links"`
+	Meta  ActTV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -147,6 +173,20 @@ const (
 	ActTV2DataTriggerType_Timer        ActTV2DataTriggerType = "TIMER"
 	ActTV2DataTriggerType_Other        ActTV2DataTriggerType = "OTHER"
 )
+
+// ActTV2Links represents a slice of ActTV2Link values with helper methods
+// for adding new links.
+type ActTV2Links []ActTV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActTV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActTV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActTV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActTV2Link{Target: target, Type: linkType})
+}
 
 type ActTV2Link struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV3.go
+++ b/EiffelActivityTriggeredEventV3.go
@@ -90,12 +90,38 @@ func (e *ActivityTriggeredV3) String() string {
 }
 
 var _ FieldSetter = &ActivityTriggeredV3{}
+var _ MetaTeller = &ActivityTriggeredV3{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityTriggeredV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityTriggeredV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityTriggeredV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityTriggeredV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityTriggeredV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityTriggeredV3 struct {
 	// Mandatory fields
-	Data  ActTV3Data   `json:"data"`
-	Links []ActTV3Link `json:"links"`
-	Meta  ActTV3Meta   `json:"meta"`
+	Data  ActTV3Data  `json:"data"`
+	Links ActTV3Links `json:"links"`
+	Meta  ActTV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -147,6 +173,20 @@ const (
 	ActTV3DataTriggerType_Timer        ActTV3DataTriggerType = "TIMER"
 	ActTV3DataTriggerType_Other        ActTV3DataTriggerType = "OTHER"
 )
+
+// ActTV3Links represents a slice of ActTV3Link values with helper methods
+// for adding new links.
+type ActTV3Links []ActTV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActTV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActTV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActTV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActTV3Link{Target: target, Type: linkType})
+}
 
 type ActTV3Link struct {
 	// Mandatory fields

--- a/EiffelActivityTriggeredEventV4.go
+++ b/EiffelActivityTriggeredEventV4.go
@@ -90,12 +90,38 @@ func (e *ActivityTriggeredV4) String() string {
 }
 
 var _ FieldSetter = &ActivityTriggeredV4{}
+var _ MetaTeller = &ActivityTriggeredV4{}
+
+// ID returns the value of the meta.id field.
+func (e ActivityTriggeredV4) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ActivityTriggeredV4) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ActivityTriggeredV4) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ActivityTriggeredV4) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ActivityTriggeredV4) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ActivityTriggeredV4 struct {
 	// Mandatory fields
-	Data  ActTV4Data   `json:"data"`
-	Links []ActTV4Link `json:"links"`
-	Meta  ActTV4Meta   `json:"meta"`
+	Data  ActTV4Data  `json:"data"`
+	Links ActTV4Links `json:"links"`
+	Meta  ActTV4Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -147,6 +173,20 @@ const (
 	ActTV4DataTriggerType_Timer        ActTV4DataTriggerType = "TIMER"
 	ActTV4DataTriggerType_Other        ActTV4DataTriggerType = "OTHER"
 )
+
+// ActTV4Links represents a slice of ActTV4Link values with helper methods
+// for adding new links.
+type ActTV4Links []ActTV4Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ActTV4Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ActTV4Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ActTV4Links) AddByID(linkType string, target string) {
+	*links = append(*links, ActTV4Link{Target: target, Type: linkType})
+}
 
 type ActTV4Link struct {
 	// Mandatory fields

--- a/EiffelAnnouncementPublishedEventV1.go
+++ b/EiffelAnnouncementPublishedEventV1.go
@@ -90,12 +90,38 @@ func (e *AnnouncementPublishedV1) String() string {
 }
 
 var _ FieldSetter = &AnnouncementPublishedV1{}
+var _ MetaTeller = &AnnouncementPublishedV1{}
+
+// ID returns the value of the meta.id field.
+func (e AnnouncementPublishedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e AnnouncementPublishedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e AnnouncementPublishedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e AnnouncementPublishedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e AnnouncementPublishedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type AnnouncementPublishedV1 struct {
 	// Mandatory fields
-	Data  AnnPV1Data   `json:"data"`
-	Links []AnnPV1Link `json:"links"`
-	Meta  AnnPV1Meta   `json:"meta"`
+	Data  AnnPV1Data  `json:"data"`
+	Links AnnPV1Links `json:"links"`
+	Meta  AnnPV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -131,6 +157,20 @@ const (
 	AnnPV1DataSeverity_Closed   AnnPV1DataSeverity = "CLOSED"
 	AnnPV1DataSeverity_Canceled AnnPV1DataSeverity = "CANCELED"
 )
+
+// AnnPV1Links represents a slice of AnnPV1Link values with helper methods
+// for adding new links.
+type AnnPV1Links []AnnPV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *AnnPV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, AnnPV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *AnnPV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, AnnPV1Link{Target: target, Type: linkType})
+}
 
 type AnnPV1Link struct {
 	// Mandatory fields

--- a/EiffelAnnouncementPublishedEventV2.go
+++ b/EiffelAnnouncementPublishedEventV2.go
@@ -90,12 +90,38 @@ func (e *AnnouncementPublishedV2) String() string {
 }
 
 var _ FieldSetter = &AnnouncementPublishedV2{}
+var _ MetaTeller = &AnnouncementPublishedV2{}
+
+// ID returns the value of the meta.id field.
+func (e AnnouncementPublishedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e AnnouncementPublishedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e AnnouncementPublishedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e AnnouncementPublishedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e AnnouncementPublishedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type AnnouncementPublishedV2 struct {
 	// Mandatory fields
-	Data  AnnPV2Data   `json:"data"`
-	Links []AnnPV2Link `json:"links"`
-	Meta  AnnPV2Meta   `json:"meta"`
+	Data  AnnPV2Data  `json:"data"`
+	Links AnnPV2Links `json:"links"`
+	Meta  AnnPV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -131,6 +157,20 @@ const (
 	AnnPV2DataSeverity_Closed   AnnPV2DataSeverity = "CLOSED"
 	AnnPV2DataSeverity_Canceled AnnPV2DataSeverity = "CANCELED"
 )
+
+// AnnPV2Links represents a slice of AnnPV2Link values with helper methods
+// for adding new links.
+type AnnPV2Links []AnnPV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *AnnPV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, AnnPV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *AnnPV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, AnnPV2Link{Target: target, Type: linkType})
+}
 
 type AnnPV2Link struct {
 	// Mandatory fields

--- a/EiffelAnnouncementPublishedEventV3.go
+++ b/EiffelAnnouncementPublishedEventV3.go
@@ -90,12 +90,38 @@ func (e *AnnouncementPublishedV3) String() string {
 }
 
 var _ FieldSetter = &AnnouncementPublishedV3{}
+var _ MetaTeller = &AnnouncementPublishedV3{}
+
+// ID returns the value of the meta.id field.
+func (e AnnouncementPublishedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e AnnouncementPublishedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e AnnouncementPublishedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e AnnouncementPublishedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e AnnouncementPublishedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type AnnouncementPublishedV3 struct {
 	// Mandatory fields
-	Data  AnnPV3Data   `json:"data"`
-	Links []AnnPV3Link `json:"links"`
-	Meta  AnnPV3Meta   `json:"meta"`
+	Data  AnnPV3Data  `json:"data"`
+	Links AnnPV3Links `json:"links"`
+	Meta  AnnPV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -131,6 +157,20 @@ const (
 	AnnPV3DataSeverity_Closed   AnnPV3DataSeverity = "CLOSED"
 	AnnPV3DataSeverity_Canceled AnnPV3DataSeverity = "CANCELED"
 )
+
+// AnnPV3Links represents a slice of AnnPV3Link values with helper methods
+// for adding new links.
+type AnnPV3Links []AnnPV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *AnnPV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, AnnPV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *AnnPV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, AnnPV3Link{Target: target, Type: linkType})
+}
 
 type AnnPV3Link struct {
 	// Mandatory fields

--- a/EiffelArtifactCreatedEventV1.go
+++ b/EiffelArtifactCreatedEventV1.go
@@ -90,12 +90,38 @@ func (e *ArtifactCreatedV1) String() string {
 }
 
 var _ FieldSetter = &ArtifactCreatedV1{}
+var _ MetaTeller = &ArtifactCreatedV1{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactCreatedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactCreatedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactCreatedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactCreatedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactCreatedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactCreatedV1 struct {
 	// Mandatory fields
-	Data  ArtCV1Data   `json:"data"`
-	Links []ArtCV1Link `json:"links"`
-	Meta  ArtCV1Meta   `json:"meta"`
+	Data  ArtCV1Data  `json:"data"`
+	Links ArtCV1Links `json:"links"`
+	Meta  ArtCV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -171,6 +197,20 @@ const (
 	ArtCV1DataRequiresImplementation_ExactlyOne ArtCV1DataRequiresImplementation = "EXACTLY_ONE"
 	ArtCV1DataRequiresImplementation_AtLeastOne ArtCV1DataRequiresImplementation = "AT_LEAST_ONE"
 )
+
+// ArtCV1Links represents a slice of ArtCV1Link values with helper methods
+// for adding new links.
+type ArtCV1Links []ArtCV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtCV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtCV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtCV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtCV1Link{Target: target, Type: linkType})
+}
 
 type ArtCV1Link struct {
 	// Mandatory fields

--- a/EiffelArtifactCreatedEventV2.go
+++ b/EiffelArtifactCreatedEventV2.go
@@ -90,12 +90,38 @@ func (e *ArtifactCreatedV2) String() string {
 }
 
 var _ FieldSetter = &ArtifactCreatedV2{}
+var _ MetaTeller = &ArtifactCreatedV2{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactCreatedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactCreatedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactCreatedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactCreatedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactCreatedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactCreatedV2 struct {
 	// Mandatory fields
-	Data  ArtCV2Data   `json:"data"`
-	Links []ArtCV2Link `json:"links"`
-	Meta  ArtCV2Meta   `json:"meta"`
+	Data  ArtCV2Data  `json:"data"`
+	Links ArtCV2Links `json:"links"`
+	Meta  ArtCV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -140,6 +166,20 @@ const (
 	ArtCV2DataRequiresImplementation_ExactlyOne ArtCV2DataRequiresImplementation = "EXACTLY_ONE"
 	ArtCV2DataRequiresImplementation_AtLeastOne ArtCV2DataRequiresImplementation = "AT_LEAST_ONE"
 )
+
+// ArtCV2Links represents a slice of ArtCV2Link values with helper methods
+// for adding new links.
+type ArtCV2Links []ArtCV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtCV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtCV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtCV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtCV2Link{Target: target, Type: linkType})
+}
 
 type ArtCV2Link struct {
 	// Mandatory fields

--- a/EiffelArtifactCreatedEventV3.go
+++ b/EiffelArtifactCreatedEventV3.go
@@ -90,12 +90,38 @@ func (e *ArtifactCreatedV3) String() string {
 }
 
 var _ FieldSetter = &ArtifactCreatedV3{}
+var _ MetaTeller = &ArtifactCreatedV3{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactCreatedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactCreatedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactCreatedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactCreatedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactCreatedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactCreatedV3 struct {
 	// Mandatory fields
-	Data  ArtCV3Data   `json:"data"`
-	Links []ArtCV3Link `json:"links"`
-	Meta  ArtCV3Meta   `json:"meta"`
+	Data  ArtCV3Data  `json:"data"`
+	Links ArtCV3Links `json:"links"`
+	Meta  ArtCV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -140,6 +166,20 @@ const (
 	ArtCV3DataRequiresImplementation_ExactlyOne ArtCV3DataRequiresImplementation = "EXACTLY_ONE"
 	ArtCV3DataRequiresImplementation_AtLeastOne ArtCV3DataRequiresImplementation = "AT_LEAST_ONE"
 )
+
+// ArtCV3Links represents a slice of ArtCV3Link values with helper methods
+// for adding new links.
+type ArtCV3Links []ArtCV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtCV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtCV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtCV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtCV3Link{Target: target, Type: linkType})
+}
 
 type ArtCV3Link struct {
 	// Mandatory fields

--- a/EiffelArtifactPublishedEventV1.go
+++ b/EiffelArtifactPublishedEventV1.go
@@ -90,12 +90,38 @@ func (e *ArtifactPublishedV1) String() string {
 }
 
 var _ FieldSetter = &ArtifactPublishedV1{}
+var _ MetaTeller = &ArtifactPublishedV1{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactPublishedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactPublishedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactPublishedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactPublishedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactPublishedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactPublishedV1 struct {
 	// Mandatory fields
-	Data  ArtPV1Data   `json:"data"`
-	Links []ArtPV1Link `json:"links"`
-	Meta  ArtPV1Meta   `json:"meta"`
+	Data  ArtPV1Data  `json:"data"`
+	Links ArtPV1Links `json:"links"`
+	Meta  ArtPV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -135,6 +161,20 @@ const (
 	ArtPV1DataLocationType_Plain       ArtPV1DataLocationType = "PLAIN"
 	ArtPV1DataLocationType_Other       ArtPV1DataLocationType = "OTHER"
 )
+
+// ArtPV1Links represents a slice of ArtPV1Link values with helper methods
+// for adding new links.
+type ArtPV1Links []ArtPV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtPV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtPV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtPV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtPV1Link{Target: target, Type: linkType})
+}
 
 type ArtPV1Link struct {
 	// Mandatory fields

--- a/EiffelArtifactPublishedEventV2.go
+++ b/EiffelArtifactPublishedEventV2.go
@@ -90,12 +90,38 @@ func (e *ArtifactPublishedV2) String() string {
 }
 
 var _ FieldSetter = &ArtifactPublishedV2{}
+var _ MetaTeller = &ArtifactPublishedV2{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactPublishedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactPublishedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactPublishedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactPublishedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactPublishedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactPublishedV2 struct {
 	// Mandatory fields
-	Data  ArtPV2Data   `json:"data"`
-	Links []ArtPV2Link `json:"links"`
-	Meta  ArtPV2Meta   `json:"meta"`
+	Data  ArtPV2Data  `json:"data"`
+	Links ArtPV2Links `json:"links"`
+	Meta  ArtPV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -135,6 +161,20 @@ const (
 	ArtPV2DataLocationType_Plain       ArtPV2DataLocationType = "PLAIN"
 	ArtPV2DataLocationType_Other       ArtPV2DataLocationType = "OTHER"
 )
+
+// ArtPV2Links represents a slice of ArtPV2Link values with helper methods
+// for adding new links.
+type ArtPV2Links []ArtPV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtPV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtPV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtPV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtPV2Link{Target: target, Type: linkType})
+}
 
 type ArtPV2Link struct {
 	// Mandatory fields

--- a/EiffelArtifactPublishedEventV3.go
+++ b/EiffelArtifactPublishedEventV3.go
@@ -90,12 +90,38 @@ func (e *ArtifactPublishedV3) String() string {
 }
 
 var _ FieldSetter = &ArtifactPublishedV3{}
+var _ MetaTeller = &ArtifactPublishedV3{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactPublishedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactPublishedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactPublishedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactPublishedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactPublishedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactPublishedV3 struct {
 	// Mandatory fields
-	Data  ArtPV3Data   `json:"data"`
-	Links []ArtPV3Link `json:"links"`
-	Meta  ArtPV3Meta   `json:"meta"`
+	Data  ArtPV3Data  `json:"data"`
+	Links ArtPV3Links `json:"links"`
+	Meta  ArtPV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -135,6 +161,20 @@ const (
 	ArtPV3DataLocationType_Plain       ArtPV3DataLocationType = "PLAIN"
 	ArtPV3DataLocationType_Other       ArtPV3DataLocationType = "OTHER"
 )
+
+// ArtPV3Links represents a slice of ArtPV3Link values with helper methods
+// for adding new links.
+type ArtPV3Links []ArtPV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtPV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtPV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtPV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtPV3Link{Target: target, Type: linkType})
+}
 
 type ArtPV3Link struct {
 	// Mandatory fields

--- a/EiffelArtifactReusedEventV1.go
+++ b/EiffelArtifactReusedEventV1.go
@@ -90,12 +90,38 @@ func (e *ArtifactReusedV1) String() string {
 }
 
 var _ FieldSetter = &ArtifactReusedV1{}
+var _ MetaTeller = &ArtifactReusedV1{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactReusedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactReusedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactReusedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactReusedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactReusedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactReusedV1 struct {
 	// Mandatory fields
-	Data  ArtRV1Data   `json:"data"`
-	Links []ArtRV1Link `json:"links"`
-	Meta  ArtRV1Meta   `json:"meta"`
+	Data  ArtRV1Data  `json:"data"`
+	Links ArtRV1Links `json:"links"`
+	Meta  ArtRV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -115,6 +141,20 @@ type ArtRV1DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// ArtRV1Links represents a slice of ArtRV1Link values with helper methods
+// for adding new links.
+type ArtRV1Links []ArtRV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtRV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtRV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtRV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtRV1Link{Target: target, Type: linkType})
 }
 
 type ArtRV1Link struct {

--- a/EiffelArtifactReusedEventV2.go
+++ b/EiffelArtifactReusedEventV2.go
@@ -90,12 +90,38 @@ func (e *ArtifactReusedV2) String() string {
 }
 
 var _ FieldSetter = &ArtifactReusedV2{}
+var _ MetaTeller = &ArtifactReusedV2{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactReusedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactReusedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactReusedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactReusedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactReusedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactReusedV2 struct {
 	// Mandatory fields
-	Data  ArtRV2Data   `json:"data"`
-	Links []ArtRV2Link `json:"links"`
-	Meta  ArtRV2Meta   `json:"meta"`
+	Data  ArtRV2Data  `json:"data"`
+	Links ArtRV2Links `json:"links"`
+	Meta  ArtRV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -115,6 +141,20 @@ type ArtRV2DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// ArtRV2Links represents a slice of ArtRV2Link values with helper methods
+// for adding new links.
+type ArtRV2Links []ArtRV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtRV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtRV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtRV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtRV2Link{Target: target, Type: linkType})
 }
 
 type ArtRV2Link struct {

--- a/EiffelArtifactReusedEventV3.go
+++ b/EiffelArtifactReusedEventV3.go
@@ -90,12 +90,38 @@ func (e *ArtifactReusedV3) String() string {
 }
 
 var _ FieldSetter = &ArtifactReusedV3{}
+var _ MetaTeller = &ArtifactReusedV3{}
+
+// ID returns the value of the meta.id field.
+func (e ArtifactReusedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ArtifactReusedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ArtifactReusedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ArtifactReusedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ArtifactReusedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ArtifactReusedV3 struct {
 	// Mandatory fields
-	Data  ArtRV3Data   `json:"data"`
-	Links []ArtRV3Link `json:"links"`
-	Meta  ArtRV3Meta   `json:"meta"`
+	Data  ArtRV3Data  `json:"data"`
+	Links ArtRV3Links `json:"links"`
+	Meta  ArtRV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -115,6 +141,20 @@ type ArtRV3DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// ArtRV3Links represents a slice of ArtRV3Link values with helper methods
+// for adding new links.
+type ArtRV3Links []ArtRV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *ArtRV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, ArtRV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *ArtRV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, ArtRV3Link{Target: target, Type: linkType})
 }
 
 type ArtRV3Link struct {

--- a/EiffelCompositionDefinedEventV1.go
+++ b/EiffelCompositionDefinedEventV1.go
@@ -90,12 +90,38 @@ func (e *CompositionDefinedV1) String() string {
 }
 
 var _ FieldSetter = &CompositionDefinedV1{}
+var _ MetaTeller = &CompositionDefinedV1{}
+
+// ID returns the value of the meta.id field.
+func (e CompositionDefinedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e CompositionDefinedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e CompositionDefinedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e CompositionDefinedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e CompositionDefinedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type CompositionDefinedV1 struct {
 	// Mandatory fields
-	Data  CDV1Data   `json:"data"`
-	Links []CDV1Link `json:"links"`
-	Meta  CDV1Meta   `json:"meta"`
+	Data  CDV1Data  `json:"data"`
+	Links CDV1Links `json:"links"`
+	Meta  CDV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -117,6 +143,20 @@ type CDV1DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// CDV1Links represents a slice of CDV1Link values with helper methods
+// for adding new links.
+type CDV1Links []CDV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *CDV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, CDV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *CDV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, CDV1Link{Target: target, Type: linkType})
 }
 
 type CDV1Link struct {

--- a/EiffelCompositionDefinedEventV2.go
+++ b/EiffelCompositionDefinedEventV2.go
@@ -90,12 +90,38 @@ func (e *CompositionDefinedV2) String() string {
 }
 
 var _ FieldSetter = &CompositionDefinedV2{}
+var _ MetaTeller = &CompositionDefinedV2{}
+
+// ID returns the value of the meta.id field.
+func (e CompositionDefinedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e CompositionDefinedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e CompositionDefinedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e CompositionDefinedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e CompositionDefinedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type CompositionDefinedV2 struct {
 	// Mandatory fields
-	Data  CDV2Data   `json:"data"`
-	Links []CDV2Link `json:"links"`
-	Meta  CDV2Meta   `json:"meta"`
+	Data  CDV2Data  `json:"data"`
+	Links CDV2Links `json:"links"`
+	Meta  CDV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -117,6 +143,20 @@ type CDV2DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// CDV2Links represents a slice of CDV2Link values with helper methods
+// for adding new links.
+type CDV2Links []CDV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *CDV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, CDV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *CDV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, CDV2Link{Target: target, Type: linkType})
 }
 
 type CDV2Link struct {

--- a/EiffelCompositionDefinedEventV3.go
+++ b/EiffelCompositionDefinedEventV3.go
@@ -90,12 +90,38 @@ func (e *CompositionDefinedV3) String() string {
 }
 
 var _ FieldSetter = &CompositionDefinedV3{}
+var _ MetaTeller = &CompositionDefinedV3{}
+
+// ID returns the value of the meta.id field.
+func (e CompositionDefinedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e CompositionDefinedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e CompositionDefinedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e CompositionDefinedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e CompositionDefinedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type CompositionDefinedV3 struct {
 	// Mandatory fields
-	Data  CDV3Data   `json:"data"`
-	Links []CDV3Link `json:"links"`
-	Meta  CDV3Meta   `json:"meta"`
+	Data  CDV3Data  `json:"data"`
+	Links CDV3Links `json:"links"`
+	Meta  CDV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -117,6 +143,20 @@ type CDV3DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// CDV3Links represents a slice of CDV3Link values with helper methods
+// for adding new links.
+type CDV3Links []CDV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *CDV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, CDV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *CDV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, CDV3Link{Target: target, Type: linkType})
 }
 
 type CDV3Link struct {

--- a/EiffelConfidenceLevelModifiedEventV1.go
+++ b/EiffelConfidenceLevelModifiedEventV1.go
@@ -90,12 +90,38 @@ func (e *ConfidenceLevelModifiedV1) String() string {
 }
 
 var _ FieldSetter = &ConfidenceLevelModifiedV1{}
+var _ MetaTeller = &ConfidenceLevelModifiedV1{}
+
+// ID returns the value of the meta.id field.
+func (e ConfidenceLevelModifiedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ConfidenceLevelModifiedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ConfidenceLevelModifiedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ConfidenceLevelModifiedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ConfidenceLevelModifiedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ConfidenceLevelModifiedV1 struct {
 	// Mandatory fields
-	Data  CLMV1Data   `json:"data"`
-	Links []CLMV1Link `json:"links"`
-	Meta  CLMV1Meta   `json:"meta"`
+	Data  CLMV1Data  `json:"data"`
+	Links CLMV1Links `json:"links"`
+	Meta  CLMV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -137,6 +163,20 @@ const (
 	CLMV1DataValue_Failure      CLMV1DataValue = "FAILURE"
 	CLMV1DataValue_Inconclusive CLMV1DataValue = "INCONCLUSIVE"
 )
+
+// CLMV1Links represents a slice of CLMV1Link values with helper methods
+// for adding new links.
+type CLMV1Links []CLMV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *CLMV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, CLMV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *CLMV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, CLMV1Link{Target: target, Type: linkType})
+}
 
 type CLMV1Link struct {
 	// Mandatory fields

--- a/EiffelConfidenceLevelModifiedEventV2.go
+++ b/EiffelConfidenceLevelModifiedEventV2.go
@@ -90,12 +90,38 @@ func (e *ConfidenceLevelModifiedV2) String() string {
 }
 
 var _ FieldSetter = &ConfidenceLevelModifiedV2{}
+var _ MetaTeller = &ConfidenceLevelModifiedV2{}
+
+// ID returns the value of the meta.id field.
+func (e ConfidenceLevelModifiedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ConfidenceLevelModifiedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ConfidenceLevelModifiedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ConfidenceLevelModifiedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ConfidenceLevelModifiedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ConfidenceLevelModifiedV2 struct {
 	// Mandatory fields
-	Data  CLMV2Data   `json:"data"`
-	Links []CLMV2Link `json:"links"`
-	Meta  CLMV2Meta   `json:"meta"`
+	Data  CLMV2Data  `json:"data"`
+	Links CLMV2Links `json:"links"`
+	Meta  CLMV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -137,6 +163,20 @@ const (
 	CLMV2DataValue_Failure      CLMV2DataValue = "FAILURE"
 	CLMV2DataValue_Inconclusive CLMV2DataValue = "INCONCLUSIVE"
 )
+
+// CLMV2Links represents a slice of CLMV2Link values with helper methods
+// for adding new links.
+type CLMV2Links []CLMV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *CLMV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, CLMV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *CLMV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, CLMV2Link{Target: target, Type: linkType})
+}
 
 type CLMV2Link struct {
 	// Mandatory fields

--- a/EiffelConfidenceLevelModifiedEventV3.go
+++ b/EiffelConfidenceLevelModifiedEventV3.go
@@ -90,12 +90,38 @@ func (e *ConfidenceLevelModifiedV3) String() string {
 }
 
 var _ FieldSetter = &ConfidenceLevelModifiedV3{}
+var _ MetaTeller = &ConfidenceLevelModifiedV3{}
+
+// ID returns the value of the meta.id field.
+func (e ConfidenceLevelModifiedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e ConfidenceLevelModifiedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e ConfidenceLevelModifiedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e ConfidenceLevelModifiedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e ConfidenceLevelModifiedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type ConfidenceLevelModifiedV3 struct {
 	// Mandatory fields
-	Data  CLMV3Data   `json:"data"`
-	Links []CLMV3Link `json:"links"`
-	Meta  CLMV3Meta   `json:"meta"`
+	Data  CLMV3Data  `json:"data"`
+	Links CLMV3Links `json:"links"`
+	Meta  CLMV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -137,6 +163,20 @@ const (
 	CLMV3DataValue_Failure      CLMV3DataValue = "FAILURE"
 	CLMV3DataValue_Inconclusive CLMV3DataValue = "INCONCLUSIVE"
 )
+
+// CLMV3Links represents a slice of CLMV3Link values with helper methods
+// for adding new links.
+type CLMV3Links []CLMV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *CLMV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, CLMV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *CLMV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, CLMV3Link{Target: target, Type: linkType})
+}
 
 type CLMV3Link struct {
 	// Mandatory fields

--- a/EiffelEnvironmentDefinedEventV1.go
+++ b/EiffelEnvironmentDefinedEventV1.go
@@ -90,12 +90,38 @@ func (e *EnvironmentDefinedV1) String() string {
 }
 
 var _ FieldSetter = &EnvironmentDefinedV1{}
+var _ MetaTeller = &EnvironmentDefinedV1{}
+
+// ID returns the value of the meta.id field.
+func (e EnvironmentDefinedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e EnvironmentDefinedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e EnvironmentDefinedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e EnvironmentDefinedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e EnvironmentDefinedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type EnvironmentDefinedV1 struct {
 	// Mandatory fields
-	Data  EDV1Data   `json:"data"`
-	Links []EDV1Link `json:"links"`
-	Meta  EDV1Meta   `json:"meta"`
+	Data  EDV1Data  `json:"data"`
+	Links EDV1Links `json:"links"`
+	Meta  EDV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -129,6 +155,20 @@ type EDV1DataHost struct {
 
 	// Optional fields
 
+}
+
+// EDV1Links represents a slice of EDV1Link values with helper methods
+// for adding new links.
+type EDV1Links []EDV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *EDV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, EDV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *EDV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, EDV1Link{Target: target, Type: linkType})
 }
 
 type EDV1Link struct {

--- a/EiffelEnvironmentDefinedEventV2.go
+++ b/EiffelEnvironmentDefinedEventV2.go
@@ -90,12 +90,38 @@ func (e *EnvironmentDefinedV2) String() string {
 }
 
 var _ FieldSetter = &EnvironmentDefinedV2{}
+var _ MetaTeller = &EnvironmentDefinedV2{}
+
+// ID returns the value of the meta.id field.
+func (e EnvironmentDefinedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e EnvironmentDefinedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e EnvironmentDefinedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e EnvironmentDefinedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e EnvironmentDefinedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type EnvironmentDefinedV2 struct {
 	// Mandatory fields
-	Data  EDV2Data   `json:"data"`
-	Links []EDV2Link `json:"links"`
-	Meta  EDV2Meta   `json:"meta"`
+	Data  EDV2Data  `json:"data"`
+	Links EDV2Links `json:"links"`
+	Meta  EDV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -129,6 +155,20 @@ type EDV2DataHost struct {
 
 	// Optional fields
 
+}
+
+// EDV2Links represents a slice of EDV2Link values with helper methods
+// for adding new links.
+type EDV2Links []EDV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *EDV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, EDV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *EDV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, EDV2Link{Target: target, Type: linkType})
 }
 
 type EDV2Link struct {

--- a/EiffelEnvironmentDefinedEventV3.go
+++ b/EiffelEnvironmentDefinedEventV3.go
@@ -90,12 +90,38 @@ func (e *EnvironmentDefinedV3) String() string {
 }
 
 var _ FieldSetter = &EnvironmentDefinedV3{}
+var _ MetaTeller = &EnvironmentDefinedV3{}
+
+// ID returns the value of the meta.id field.
+func (e EnvironmentDefinedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e EnvironmentDefinedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e EnvironmentDefinedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e EnvironmentDefinedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e EnvironmentDefinedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type EnvironmentDefinedV3 struct {
 	// Mandatory fields
-	Data  EDV3Data   `json:"data"`
-	Links []EDV3Link `json:"links"`
-	Meta  EDV3Meta   `json:"meta"`
+	Data  EDV3Data  `json:"data"`
+	Links EDV3Links `json:"links"`
+	Meta  EDV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -129,6 +155,20 @@ type EDV3DataHost struct {
 
 	// Optional fields
 
+}
+
+// EDV3Links represents a slice of EDV3Link values with helper methods
+// for adding new links.
+type EDV3Links []EDV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *EDV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, EDV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *EDV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, EDV3Link{Target: target, Type: linkType})
 }
 
 type EDV3Link struct {

--- a/EiffelFlowContextDefinedEventV1.go
+++ b/EiffelFlowContextDefinedEventV1.go
@@ -90,12 +90,38 @@ func (e *FlowContextDefinedV1) String() string {
 }
 
 var _ FieldSetter = &FlowContextDefinedV1{}
+var _ MetaTeller = &FlowContextDefinedV1{}
+
+// ID returns the value of the meta.id field.
+func (e FlowContextDefinedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e FlowContextDefinedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e FlowContextDefinedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e FlowContextDefinedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e FlowContextDefinedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type FlowContextDefinedV1 struct {
 	// Mandatory fields
-	Data  FCDV1Data   `json:"data"`
-	Links []FCDV1Link `json:"links"`
-	Meta  FCDV1Meta   `json:"meta"`
+	Data  FCDV1Data  `json:"data"`
+	Links FCDV1Links `json:"links"`
+	Meta  FCDV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -120,6 +146,20 @@ type FCDV1DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// FCDV1Links represents a slice of FCDV1Link values with helper methods
+// for adding new links.
+type FCDV1Links []FCDV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *FCDV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, FCDV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *FCDV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, FCDV1Link{Target: target, Type: linkType})
 }
 
 type FCDV1Link struct {

--- a/EiffelFlowContextDefinedEventV2.go
+++ b/EiffelFlowContextDefinedEventV2.go
@@ -90,12 +90,38 @@ func (e *FlowContextDefinedV2) String() string {
 }
 
 var _ FieldSetter = &FlowContextDefinedV2{}
+var _ MetaTeller = &FlowContextDefinedV2{}
+
+// ID returns the value of the meta.id field.
+func (e FlowContextDefinedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e FlowContextDefinedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e FlowContextDefinedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e FlowContextDefinedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e FlowContextDefinedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type FlowContextDefinedV2 struct {
 	// Mandatory fields
-	Data  FCDV2Data   `json:"data"`
-	Links []FCDV2Link `json:"links"`
-	Meta  FCDV2Meta   `json:"meta"`
+	Data  FCDV2Data  `json:"data"`
+	Links FCDV2Links `json:"links"`
+	Meta  FCDV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -120,6 +146,20 @@ type FCDV2DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// FCDV2Links represents a slice of FCDV2Link values with helper methods
+// for adding new links.
+type FCDV2Links []FCDV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *FCDV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, FCDV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *FCDV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, FCDV2Link{Target: target, Type: linkType})
 }
 
 type FCDV2Link struct {

--- a/EiffelFlowContextDefinedEventV3.go
+++ b/EiffelFlowContextDefinedEventV3.go
@@ -90,12 +90,38 @@ func (e *FlowContextDefinedV3) String() string {
 }
 
 var _ FieldSetter = &FlowContextDefinedV3{}
+var _ MetaTeller = &FlowContextDefinedV3{}
+
+// ID returns the value of the meta.id field.
+func (e FlowContextDefinedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e FlowContextDefinedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e FlowContextDefinedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e FlowContextDefinedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e FlowContextDefinedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type FlowContextDefinedV3 struct {
 	// Mandatory fields
-	Data  FCDV3Data   `json:"data"`
-	Links []FCDV3Link `json:"links"`
-	Meta  FCDV3Meta   `json:"meta"`
+	Data  FCDV3Data  `json:"data"`
+	Links FCDV3Links `json:"links"`
+	Meta  FCDV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -120,6 +146,20 @@ type FCDV3DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// FCDV3Links represents a slice of FCDV3Link values with helper methods
+// for adding new links.
+type FCDV3Links []FCDV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *FCDV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, FCDV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *FCDV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, FCDV3Link{Target: target, Type: linkType})
 }
 
 type FCDV3Link struct {

--- a/EiffelIssueDefinedEventV1.go
+++ b/EiffelIssueDefinedEventV1.go
@@ -90,14 +90,40 @@ func (e *IssueDefinedV1) String() string {
 }
 
 var _ FieldSetter = &IssueDefinedV1{}
+var _ MetaTeller = &IssueDefinedV1{}
+
+// ID returns the value of the meta.id field.
+func (e IssueDefinedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueDefinedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueDefinedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueDefinedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueDefinedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueDefinedV1 struct {
 	// Mandatory fields
 
 	// Optional fields
-	Data  IDV1Data   `json:"data,omitempty"`
-	Links []IDV1Link `json:"links,omitempty"`
-	Meta  IDV1Meta   `json:"meta,omitempty"`
+	Data  IDV1Data  `json:"data,omitempty"`
+	Links IDV1Links `json:"links,omitempty"`
+	Meta  IDV1Meta  `json:"meta,omitempty"`
 }
 
 type IDV1Data struct {
@@ -131,6 +157,20 @@ const (
 	IDV1DataType_Requirement IDV1DataType = "REQUIREMENT"
 	IDV1DataType_Other       IDV1DataType = "OTHER"
 )
+
+// IDV1Links represents a slice of IDV1Link values with helper methods
+// for adding new links.
+type IDV1Links []IDV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IDV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IDV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IDV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, IDV1Link{Target: target, Type: linkType})
+}
 
 type IDV1Link struct {
 	// Mandatory fields

--- a/EiffelIssueDefinedEventV2.go
+++ b/EiffelIssueDefinedEventV2.go
@@ -90,14 +90,40 @@ func (e *IssueDefinedV2) String() string {
 }
 
 var _ FieldSetter = &IssueDefinedV2{}
+var _ MetaTeller = &IssueDefinedV2{}
+
+// ID returns the value of the meta.id field.
+func (e IssueDefinedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueDefinedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueDefinedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueDefinedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueDefinedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueDefinedV2 struct {
 	// Mandatory fields
 
 	// Optional fields
-	Data  IDV2Data   `json:"data,omitempty"`
-	Links []IDV2Link `json:"links,omitempty"`
-	Meta  IDV2Meta   `json:"meta,omitempty"`
+	Data  IDV2Data  `json:"data,omitempty"`
+	Links IDV2Links `json:"links,omitempty"`
+	Meta  IDV2Meta  `json:"meta,omitempty"`
 }
 
 type IDV2Data struct {
@@ -131,6 +157,20 @@ const (
 	IDV2DataType_Requirement IDV2DataType = "REQUIREMENT"
 	IDV2DataType_Other       IDV2DataType = "OTHER"
 )
+
+// IDV2Links represents a slice of IDV2Link values with helper methods
+// for adding new links.
+type IDV2Links []IDV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IDV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IDV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IDV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, IDV2Link{Target: target, Type: linkType})
+}
 
 type IDV2Link struct {
 	// Mandatory fields

--- a/EiffelIssueDefinedEventV3.go
+++ b/EiffelIssueDefinedEventV3.go
@@ -90,14 +90,40 @@ func (e *IssueDefinedV3) String() string {
 }
 
 var _ FieldSetter = &IssueDefinedV3{}
+var _ MetaTeller = &IssueDefinedV3{}
+
+// ID returns the value of the meta.id field.
+func (e IssueDefinedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueDefinedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueDefinedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueDefinedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueDefinedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueDefinedV3 struct {
 	// Mandatory fields
 
 	// Optional fields
-	Data  IDV3Data   `json:"data,omitempty"`
-	Links []IDV3Link `json:"links,omitempty"`
-	Meta  IDV3Meta   `json:"meta,omitempty"`
+	Data  IDV3Data  `json:"data,omitempty"`
+	Links IDV3Links `json:"links,omitempty"`
+	Meta  IDV3Meta  `json:"meta,omitempty"`
 }
 
 type IDV3Data struct {
@@ -131,6 +157,20 @@ const (
 	IDV3DataType_Requirement IDV3DataType = "REQUIREMENT"
 	IDV3DataType_Other       IDV3DataType = "OTHER"
 )
+
+// IDV3Links represents a slice of IDV3Link values with helper methods
+// for adding new links.
+type IDV3Links []IDV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IDV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IDV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IDV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, IDV3Link{Target: target, Type: linkType})
+}
 
 type IDV3Link struct {
 	// Mandatory fields

--- a/EiffelIssueVerifiedEventV1.go
+++ b/EiffelIssueVerifiedEventV1.go
@@ -90,12 +90,38 @@ func (e *IssueVerifiedV1) String() string {
 }
 
 var _ FieldSetter = &IssueVerifiedV1{}
+var _ MetaTeller = &IssueVerifiedV1{}
+
+// ID returns the value of the meta.id field.
+func (e IssueVerifiedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueVerifiedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueVerifiedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueVerifiedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueVerifiedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueVerifiedV1 struct {
 	// Mandatory fields
-	Data  IVV1Data   `json:"data"`
-	Links []IVV1Link `json:"links"`
-	Meta  IVV1Meta   `json:"meta"`
+	Data  IVV1Data  `json:"data"`
+	Links IVV1Links `json:"links"`
+	Meta  IVV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -148,6 +174,20 @@ const (
 	IVV1DataIssueValue_Failure      IVV1DataIssueValue = "FAILURE"
 	IVV1DataIssueValue_Inconclusive IVV1DataIssueValue = "INCONCLUSIVE"
 )
+
+// IVV1Links represents a slice of IVV1Link values with helper methods
+// for adding new links.
+type IVV1Links []IVV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IVV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IVV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IVV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, IVV1Link{Target: target, Type: linkType})
+}
 
 type IVV1Link struct {
 	// Mandatory fields

--- a/EiffelIssueVerifiedEventV2.go
+++ b/EiffelIssueVerifiedEventV2.go
@@ -90,12 +90,38 @@ func (e *IssueVerifiedV2) String() string {
 }
 
 var _ FieldSetter = &IssueVerifiedV2{}
+var _ MetaTeller = &IssueVerifiedV2{}
+
+// ID returns the value of the meta.id field.
+func (e IssueVerifiedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueVerifiedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueVerifiedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueVerifiedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueVerifiedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueVerifiedV2 struct {
 	// Mandatory fields
-	Data  IVV2Data   `json:"data"`
-	Links []IVV2Link `json:"links"`
-	Meta  IVV2Meta   `json:"meta"`
+	Data  IVV2Data  `json:"data"`
+	Links IVV2Links `json:"links"`
+	Meta  IVV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -115,6 +141,20 @@ type IVV2DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// IVV2Links represents a slice of IVV2Link values with helper methods
+// for adding new links.
+type IVV2Links []IVV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IVV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IVV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IVV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, IVV2Link{Target: target, Type: linkType})
 }
 
 type IVV2Link struct {

--- a/EiffelIssueVerifiedEventV3.go
+++ b/EiffelIssueVerifiedEventV3.go
@@ -90,12 +90,38 @@ func (e *IssueVerifiedV3) String() string {
 }
 
 var _ FieldSetter = &IssueVerifiedV3{}
+var _ MetaTeller = &IssueVerifiedV3{}
+
+// ID returns the value of the meta.id field.
+func (e IssueVerifiedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueVerifiedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueVerifiedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueVerifiedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueVerifiedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueVerifiedV3 struct {
 	// Mandatory fields
-	Data  IVV3Data   `json:"data"`
-	Links []IVV3Link `json:"links"`
-	Meta  IVV3Meta   `json:"meta"`
+	Data  IVV3Data  `json:"data"`
+	Links IVV3Links `json:"links"`
+	Meta  IVV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -115,6 +141,20 @@ type IVV3DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// IVV3Links represents a slice of IVV3Link values with helper methods
+// for adding new links.
+type IVV3Links []IVV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IVV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IVV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IVV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, IVV3Link{Target: target, Type: linkType})
 }
 
 type IVV3Link struct {

--- a/EiffelIssueVerifiedEventV4.go
+++ b/EiffelIssueVerifiedEventV4.go
@@ -90,12 +90,38 @@ func (e *IssueVerifiedV4) String() string {
 }
 
 var _ FieldSetter = &IssueVerifiedV4{}
+var _ MetaTeller = &IssueVerifiedV4{}
+
+// ID returns the value of the meta.id field.
+func (e IssueVerifiedV4) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e IssueVerifiedV4) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e IssueVerifiedV4) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e IssueVerifiedV4) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e IssueVerifiedV4) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type IssueVerifiedV4 struct {
 	// Mandatory fields
-	Data  IVV4Data   `json:"data"`
-	Links []IVV4Link `json:"links"`
-	Meta  IVV4Meta   `json:"meta"`
+	Data  IVV4Data  `json:"data"`
+	Links IVV4Links `json:"links"`
+	Meta  IVV4Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -115,6 +141,20 @@ type IVV4DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// IVV4Links represents a slice of IVV4Link values with helper methods
+// for adding new links.
+type IVV4Links []IVV4Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *IVV4Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, IVV4Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *IVV4Links) AddByID(linkType string, target string) {
+	*links = append(*links, IVV4Link{Target: target, Type: linkType})
 }
 
 type IVV4Link struct {

--- a/EiffelSourceChangeCreatedEventV1.go
+++ b/EiffelSourceChangeCreatedEventV1.go
@@ -90,12 +90,38 @@ func (e *SourceChangeCreatedV1) String() string {
 }
 
 var _ FieldSetter = &SourceChangeCreatedV1{}
+var _ MetaTeller = &SourceChangeCreatedV1{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeCreatedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeCreatedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeCreatedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeCreatedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeCreatedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeCreatedV1 struct {
 	// Mandatory fields
-	Data  SCCV1Data   `json:"data"`
-	Links []SCCV1Link `json:"links"`
-	Meta  SCCV1Meta   `json:"meta"`
+	Data  SCCV1Data  `json:"data"`
+	Links SCCV1Links `json:"links"`
+	Meta  SCCV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -184,6 +210,20 @@ type SCCV1DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCCV1Links represents a slice of SCCV1Link values with helper methods
+// for adding new links.
+type SCCV1Links []SCCV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCCV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCCV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCCV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCCV1Link{Target: target, Type: linkType})
 }
 
 type SCCV1Link struct {

--- a/EiffelSourceChangeCreatedEventV2.go
+++ b/EiffelSourceChangeCreatedEventV2.go
@@ -90,12 +90,38 @@ func (e *SourceChangeCreatedV2) String() string {
 }
 
 var _ FieldSetter = &SourceChangeCreatedV2{}
+var _ MetaTeller = &SourceChangeCreatedV2{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeCreatedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeCreatedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeCreatedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeCreatedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeCreatedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeCreatedV2 struct {
 	// Mandatory fields
-	Data  SCCV2Data   `json:"data"`
-	Links []SCCV2Link `json:"links"`
-	Meta  SCCV2Meta   `json:"meta"`
+	Data  SCCV2Data  `json:"data"`
+	Links SCCV2Links `json:"links"`
+	Meta  SCCV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -183,6 +209,20 @@ type SCCV2DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCCV2Links represents a slice of SCCV2Link values with helper methods
+// for adding new links.
+type SCCV2Links []SCCV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCCV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCCV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCCV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCCV2Link{Target: target, Type: linkType})
 }
 
 type SCCV2Link struct {

--- a/EiffelSourceChangeCreatedEventV3.go
+++ b/EiffelSourceChangeCreatedEventV3.go
@@ -90,12 +90,38 @@ func (e *SourceChangeCreatedV3) String() string {
 }
 
 var _ FieldSetter = &SourceChangeCreatedV3{}
+var _ MetaTeller = &SourceChangeCreatedV3{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeCreatedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeCreatedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeCreatedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeCreatedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeCreatedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeCreatedV3 struct {
 	// Mandatory fields
-	Data  SCCV3Data   `json:"data"`
-	Links []SCCV3Link `json:"links"`
-	Meta  SCCV3Meta   `json:"meta"`
+	Data  SCCV3Data  `json:"data"`
+	Links SCCV3Links `json:"links"`
+	Meta  SCCV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -183,6 +209,20 @@ type SCCV3DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCCV3Links represents a slice of SCCV3Link values with helper methods
+// for adding new links.
+type SCCV3Links []SCCV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCCV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCCV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCCV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCCV3Link{Target: target, Type: linkType})
 }
 
 type SCCV3Link struct {

--- a/EiffelSourceChangeCreatedEventV4.go
+++ b/EiffelSourceChangeCreatedEventV4.go
@@ -90,12 +90,38 @@ func (e *SourceChangeCreatedV4) String() string {
 }
 
 var _ FieldSetter = &SourceChangeCreatedV4{}
+var _ MetaTeller = &SourceChangeCreatedV4{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeCreatedV4) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeCreatedV4) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeCreatedV4) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeCreatedV4) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeCreatedV4) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeCreatedV4 struct {
 	// Mandatory fields
-	Data  SCCV4Data   `json:"data"`
-	Links []SCCV4Link `json:"links"`
-	Meta  SCCV4Meta   `json:"meta"`
+	Data  SCCV4Data  `json:"data"`
+	Links SCCV4Links `json:"links"`
+	Meta  SCCV4Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -183,6 +209,20 @@ type SCCV4DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCCV4Links represents a slice of SCCV4Link values with helper methods
+// for adding new links.
+type SCCV4Links []SCCV4Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCCV4Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCCV4Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCCV4Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCCV4Link{Target: target, Type: linkType})
 }
 
 type SCCV4Link struct {

--- a/EiffelSourceChangeSubmittedEventV1.go
+++ b/EiffelSourceChangeSubmittedEventV1.go
@@ -90,12 +90,38 @@ func (e *SourceChangeSubmittedV1) String() string {
 }
 
 var _ FieldSetter = &SourceChangeSubmittedV1{}
+var _ MetaTeller = &SourceChangeSubmittedV1{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeSubmittedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeSubmittedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeSubmittedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeSubmittedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeSubmittedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeSubmittedV1 struct {
 	// Mandatory fields
-	Data  SCSV1Data   `json:"data"`
-	Links []SCSV1Link `json:"links"`
-	Meta  SCSV1Meta   `json:"meta"`
+	Data  SCSV1Data  `json:"data"`
+	Links SCSV1Links `json:"links"`
+	Meta  SCSV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -170,6 +196,20 @@ type SCSV1DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCSV1Links represents a slice of SCSV1Link values with helper methods
+// for adding new links.
+type SCSV1Links []SCSV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCSV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCSV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCSV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCSV1Link{Target: target, Type: linkType})
 }
 
 type SCSV1Link struct {

--- a/EiffelSourceChangeSubmittedEventV2.go
+++ b/EiffelSourceChangeSubmittedEventV2.go
@@ -90,12 +90,38 @@ func (e *SourceChangeSubmittedV2) String() string {
 }
 
 var _ FieldSetter = &SourceChangeSubmittedV2{}
+var _ MetaTeller = &SourceChangeSubmittedV2{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeSubmittedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeSubmittedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeSubmittedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeSubmittedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeSubmittedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeSubmittedV2 struct {
 	// Mandatory fields
-	Data  SCSV2Data   `json:"data"`
-	Links []SCSV2Link `json:"links"`
-	Meta  SCSV2Meta   `json:"meta"`
+	Data  SCSV2Data  `json:"data"`
+	Links SCSV2Links `json:"links"`
+	Meta  SCSV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -170,6 +196,20 @@ type SCSV2DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCSV2Links represents a slice of SCSV2Link values with helper methods
+// for adding new links.
+type SCSV2Links []SCSV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCSV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCSV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCSV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCSV2Link{Target: target, Type: linkType})
 }
 
 type SCSV2Link struct {

--- a/EiffelSourceChangeSubmittedEventV3.go
+++ b/EiffelSourceChangeSubmittedEventV3.go
@@ -90,12 +90,38 @@ func (e *SourceChangeSubmittedV3) String() string {
 }
 
 var _ FieldSetter = &SourceChangeSubmittedV3{}
+var _ MetaTeller = &SourceChangeSubmittedV3{}
+
+// ID returns the value of the meta.id field.
+func (e SourceChangeSubmittedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e SourceChangeSubmittedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e SourceChangeSubmittedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e SourceChangeSubmittedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e SourceChangeSubmittedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type SourceChangeSubmittedV3 struct {
 	// Mandatory fields
-	Data  SCSV3Data   `json:"data"`
-	Links []SCSV3Link `json:"links"`
-	Meta  SCSV3Meta   `json:"meta"`
+	Data  SCSV3Data  `json:"data"`
+	Links SCSV3Links `json:"links"`
+	Meta  SCSV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -170,6 +196,20 @@ type SCSV3DataSvnIdentifier struct {
 
 	// Optional fields
 	RepoName string `json:"repoName,omitempty"`
+}
+
+// SCSV3Links represents a slice of SCSV3Link values with helper methods
+// for adding new links.
+type SCSV3Links []SCSV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *SCSV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, SCSV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *SCSV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, SCSV3Link{Target: target, Type: linkType})
 }
 
 type SCSV3Link struct {

--- a/EiffelTestCaseCanceledEventV1.go
+++ b/EiffelTestCaseCanceledEventV1.go
@@ -90,12 +90,38 @@ func (e *TestCaseCanceledV1) String() string {
 }
 
 var _ FieldSetter = &TestCaseCanceledV1{}
+var _ MetaTeller = &TestCaseCanceledV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseCanceledV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseCanceledV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseCanceledV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseCanceledV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseCanceledV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseCanceledV1 struct {
 	// Mandatory fields
-	Data  TCCV1Data   `json:"data"`
-	Links []TCCV1Link `json:"links"`
-	Meta  TCCV1Meta   `json:"meta"`
+	Data  TCCV1Data  `json:"data"`
+	Links TCCV1Links `json:"links"`
+	Meta  TCCV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -116,6 +142,20 @@ type TCCV1DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// TCCV1Links represents a slice of TCCV1Link values with helper methods
+// for adding new links.
+type TCCV1Links []TCCV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCCV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCCV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCCV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCCV1Link{Target: target, Type: linkType})
 }
 
 type TCCV1Link struct {

--- a/EiffelTestCaseCanceledEventV2.go
+++ b/EiffelTestCaseCanceledEventV2.go
@@ -90,12 +90,38 @@ func (e *TestCaseCanceledV2) String() string {
 }
 
 var _ FieldSetter = &TestCaseCanceledV2{}
+var _ MetaTeller = &TestCaseCanceledV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseCanceledV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseCanceledV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseCanceledV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseCanceledV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseCanceledV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseCanceledV2 struct {
 	// Mandatory fields
-	Data  TCCV2Data   `json:"data"`
-	Links []TCCV2Link `json:"links"`
-	Meta  TCCV2Meta   `json:"meta"`
+	Data  TCCV2Data  `json:"data"`
+	Links TCCV2Links `json:"links"`
+	Meta  TCCV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -116,6 +142,20 @@ type TCCV2DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// TCCV2Links represents a slice of TCCV2Link values with helper methods
+// for adding new links.
+type TCCV2Links []TCCV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCCV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCCV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCCV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCCV2Link{Target: target, Type: linkType})
 }
 
 type TCCV2Link struct {

--- a/EiffelTestCaseCanceledEventV3.go
+++ b/EiffelTestCaseCanceledEventV3.go
@@ -90,12 +90,38 @@ func (e *TestCaseCanceledV3) String() string {
 }
 
 var _ FieldSetter = &TestCaseCanceledV3{}
+var _ MetaTeller = &TestCaseCanceledV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseCanceledV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseCanceledV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseCanceledV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseCanceledV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseCanceledV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseCanceledV3 struct {
 	// Mandatory fields
-	Data  TCCV3Data   `json:"data"`
-	Links []TCCV3Link `json:"links"`
-	Meta  TCCV3Meta   `json:"meta"`
+	Data  TCCV3Data  `json:"data"`
+	Links TCCV3Links `json:"links"`
+	Meta  TCCV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -116,6 +142,20 @@ type TCCV3DataCustomDatum struct {
 
 	// Optional fields
 
+}
+
+// TCCV3Links represents a slice of TCCV3Link values with helper methods
+// for adding new links.
+type TCCV3Links []TCCV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCCV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCCV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCCV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCCV3Link{Target: target, Type: linkType})
 }
 
 type TCCV3Link struct {

--- a/EiffelTestCaseFinishedEventV1.go
+++ b/EiffelTestCaseFinishedEventV1.go
@@ -90,12 +90,38 @@ func (e *TestCaseFinishedV1) String() string {
 }
 
 var _ FieldSetter = &TestCaseFinishedV1{}
+var _ MetaTeller = &TestCaseFinishedV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseFinishedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseFinishedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseFinishedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseFinishedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseFinishedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseFinishedV1 struct {
 	// Mandatory fields
-	Data  TCFV1Data   `json:"data"`
-	Links []TCFV1Link `json:"links"`
-	Meta  TCFV1Meta   `json:"meta"`
+	Data  TCFV1Data  `json:"data"`
+	Links TCFV1Links `json:"links"`
+	Meta  TCFV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -163,6 +189,20 @@ type TCFV1DataPersistentLog struct {
 
 	// Optional fields
 
+}
+
+// TCFV1Links represents a slice of TCFV1Link values with helper methods
+// for adding new links.
+type TCFV1Links []TCFV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCFV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCFV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCFV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCFV1Link{Target: target, Type: linkType})
 }
 
 type TCFV1Link struct {

--- a/EiffelTestCaseFinishedEventV2.go
+++ b/EiffelTestCaseFinishedEventV2.go
@@ -90,12 +90,38 @@ func (e *TestCaseFinishedV2) String() string {
 }
 
 var _ FieldSetter = &TestCaseFinishedV2{}
+var _ MetaTeller = &TestCaseFinishedV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseFinishedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseFinishedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseFinishedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseFinishedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseFinishedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseFinishedV2 struct {
 	// Mandatory fields
-	Data  TCFV2Data   `json:"data"`
-	Links []TCFV2Link `json:"links"`
-	Meta  TCFV2Meta   `json:"meta"`
+	Data  TCFV2Data  `json:"data"`
+	Links TCFV2Links `json:"links"`
+	Meta  TCFV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -163,6 +189,20 @@ type TCFV2DataPersistentLog struct {
 
 	// Optional fields
 
+}
+
+// TCFV2Links represents a slice of TCFV2Link values with helper methods
+// for adding new links.
+type TCFV2Links []TCFV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCFV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCFV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCFV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCFV2Link{Target: target, Type: linkType})
 }
 
 type TCFV2Link struct {

--- a/EiffelTestCaseFinishedEventV3.go
+++ b/EiffelTestCaseFinishedEventV3.go
@@ -90,12 +90,38 @@ func (e *TestCaseFinishedV3) String() string {
 }
 
 var _ FieldSetter = &TestCaseFinishedV3{}
+var _ MetaTeller = &TestCaseFinishedV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseFinishedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseFinishedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseFinishedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseFinishedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseFinishedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseFinishedV3 struct {
 	// Mandatory fields
-	Data  TCFV3Data   `json:"data"`
-	Links []TCFV3Link `json:"links"`
-	Meta  TCFV3Meta   `json:"meta"`
+	Data  TCFV3Data  `json:"data"`
+	Links TCFV3Links `json:"links"`
+	Meta  TCFV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -164,6 +190,20 @@ type TCFV3DataPersistentLog struct {
 	// Optional fields
 	MediaType string   `json:"mediaType,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
+}
+
+// TCFV3Links represents a slice of TCFV3Link values with helper methods
+// for adding new links.
+type TCFV3Links []TCFV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCFV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCFV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCFV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCFV3Link{Target: target, Type: linkType})
 }
 
 type TCFV3Link struct {

--- a/EiffelTestCaseStartedEventV1.go
+++ b/EiffelTestCaseStartedEventV1.go
@@ -90,12 +90,38 @@ func (e *TestCaseStartedV1) String() string {
 }
 
 var _ FieldSetter = &TestCaseStartedV1{}
+var _ MetaTeller = &TestCaseStartedV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseStartedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseStartedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseStartedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseStartedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseStartedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseStartedV1 struct {
 	// Mandatory fields
-	Data  TCSV1Data   `json:"data"`
-	Links []TCSV1Link `json:"links"`
-	Meta  TCSV1Meta   `json:"meta"`
+	Data  TCSV1Data  `json:"data"`
+	Links TCSV1Links `json:"links"`
+	Meta  TCSV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -126,6 +152,20 @@ type TCSV1DataLiveLog struct {
 
 	// Optional fields
 
+}
+
+// TCSV1Links represents a slice of TCSV1Link values with helper methods
+// for adding new links.
+type TCSV1Links []TCSV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCSV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCSV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCSV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCSV1Link{Target: target, Type: linkType})
 }
 
 type TCSV1Link struct {

--- a/EiffelTestCaseStartedEventV2.go
+++ b/EiffelTestCaseStartedEventV2.go
@@ -90,12 +90,38 @@ func (e *TestCaseStartedV2) String() string {
 }
 
 var _ FieldSetter = &TestCaseStartedV2{}
+var _ MetaTeller = &TestCaseStartedV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseStartedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseStartedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseStartedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseStartedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseStartedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseStartedV2 struct {
 	// Mandatory fields
-	Data  TCSV2Data   `json:"data"`
-	Links []TCSV2Link `json:"links"`
-	Meta  TCSV2Meta   `json:"meta"`
+	Data  TCSV2Data  `json:"data"`
+	Links TCSV2Links `json:"links"`
+	Meta  TCSV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -126,6 +152,20 @@ type TCSV2DataLiveLog struct {
 
 	// Optional fields
 
+}
+
+// TCSV2Links represents a slice of TCSV2Link values with helper methods
+// for adding new links.
+type TCSV2Links []TCSV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCSV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCSV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCSV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCSV2Link{Target: target, Type: linkType})
 }
 
 type TCSV2Link struct {

--- a/EiffelTestCaseStartedEventV3.go
+++ b/EiffelTestCaseStartedEventV3.go
@@ -90,12 +90,38 @@ func (e *TestCaseStartedV3) String() string {
 }
 
 var _ FieldSetter = &TestCaseStartedV3{}
+var _ MetaTeller = &TestCaseStartedV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseStartedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseStartedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseStartedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseStartedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseStartedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseStartedV3 struct {
 	// Mandatory fields
-	Data  TCSV3Data   `json:"data"`
-	Links []TCSV3Link `json:"links"`
-	Meta  TCSV3Meta   `json:"meta"`
+	Data  TCSV3Data  `json:"data"`
+	Links TCSV3Links `json:"links"`
+	Meta  TCSV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -127,6 +153,20 @@ type TCSV3DataLiveLog struct {
 	// Optional fields
 	MediaType string   `json:"mediaType,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
+}
+
+// TCSV3Links represents a slice of TCSV3Link values with helper methods
+// for adding new links.
+type TCSV3Links []TCSV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCSV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCSV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCSV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCSV3Link{Target: target, Type: linkType})
 }
 
 type TCSV3Link struct {

--- a/EiffelTestCaseTriggeredEventV1.go
+++ b/EiffelTestCaseTriggeredEventV1.go
@@ -90,12 +90,38 @@ func (e *TestCaseTriggeredV1) String() string {
 }
 
 var _ FieldSetter = &TestCaseTriggeredV1{}
+var _ MetaTeller = &TestCaseTriggeredV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseTriggeredV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseTriggeredV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseTriggeredV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseTriggeredV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseTriggeredV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseTriggeredV1 struct {
 	// Mandatory fields
-	Data  TCTV1Data   `json:"data"`
-	Links []TCTV1Link `json:"links"`
-	Meta  TCTV1Meta   `json:"meta"`
+	Data  TCTV1Data  `json:"data"`
+	Links TCTV1Links `json:"links"`
+	Meta  TCTV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -167,6 +193,20 @@ const (
 	TCTV1DataTriggerType_Timer        TCTV1DataTriggerType = "TIMER"
 	TCTV1DataTriggerType_Other        TCTV1DataTriggerType = "OTHER"
 )
+
+// TCTV1Links represents a slice of TCTV1Link values with helper methods
+// for adding new links.
+type TCTV1Links []TCTV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCTV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCTV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCTV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCTV1Link{Target: target, Type: linkType})
+}
 
 type TCTV1Link struct {
 	// Mandatory fields

--- a/EiffelTestCaseTriggeredEventV2.go
+++ b/EiffelTestCaseTriggeredEventV2.go
@@ -90,12 +90,38 @@ func (e *TestCaseTriggeredV2) String() string {
 }
 
 var _ FieldSetter = &TestCaseTriggeredV2{}
+var _ MetaTeller = &TestCaseTriggeredV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseTriggeredV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseTriggeredV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseTriggeredV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseTriggeredV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseTriggeredV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseTriggeredV2 struct {
 	// Mandatory fields
-	Data  TCTV2Data   `json:"data"`
-	Links []TCTV2Link `json:"links"`
-	Meta  TCTV2Meta   `json:"meta"`
+	Data  TCTV2Data  `json:"data"`
+	Links TCTV2Links `json:"links"`
+	Meta  TCTV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -167,6 +193,20 @@ const (
 	TCTV2DataTriggerType_Timer        TCTV2DataTriggerType = "TIMER"
 	TCTV2DataTriggerType_Other        TCTV2DataTriggerType = "OTHER"
 )
+
+// TCTV2Links represents a slice of TCTV2Link values with helper methods
+// for adding new links.
+type TCTV2Links []TCTV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCTV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCTV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCTV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCTV2Link{Target: target, Type: linkType})
+}
 
 type TCTV2Link struct {
 	// Mandatory fields

--- a/EiffelTestCaseTriggeredEventV3.go
+++ b/EiffelTestCaseTriggeredEventV3.go
@@ -90,12 +90,38 @@ func (e *TestCaseTriggeredV3) String() string {
 }
 
 var _ FieldSetter = &TestCaseTriggeredV3{}
+var _ MetaTeller = &TestCaseTriggeredV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestCaseTriggeredV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestCaseTriggeredV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestCaseTriggeredV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestCaseTriggeredV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestCaseTriggeredV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestCaseTriggeredV3 struct {
 	// Mandatory fields
-	Data  TCTV3Data   `json:"data"`
-	Links []TCTV3Link `json:"links"`
-	Meta  TCTV3Meta   `json:"meta"`
+	Data  TCTV3Data  `json:"data"`
+	Links TCTV3Links `json:"links"`
+	Meta  TCTV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -167,6 +193,20 @@ const (
 	TCTV3DataTriggerType_Timer        TCTV3DataTriggerType = "TIMER"
 	TCTV3DataTriggerType_Other        TCTV3DataTriggerType = "OTHER"
 )
+
+// TCTV3Links represents a slice of TCTV3Link values with helper methods
+// for adding new links.
+type TCTV3Links []TCTV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TCTV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TCTV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TCTV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TCTV3Link{Target: target, Type: linkType})
+}
 
 type TCTV3Link struct {
 	// Mandatory fields

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
@@ -90,12 +90,38 @@ func (e *TestExecutionRecipeCollectionCreatedV1) String() string {
 }
 
 var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV1{}
+var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestExecutionRecipeCollectionCreatedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestExecutionRecipeCollectionCreatedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestExecutionRecipeCollectionCreatedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestExecutionRecipeCollectionCreatedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestExecutionRecipeCollectionCreatedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestExecutionRecipeCollectionCreatedV1 struct {
 	// Mandatory fields
-	Data  TERCCV1Data   `json:"data"`
-	Links []TERCCV1Link `json:"links"`
-	Meta  TERCCV1Meta   `json:"meta"`
+	Data  TERCCV1Data  `json:"data"`
+	Links TERCCV1Links `json:"links"`
+	Meta  TERCCV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -164,6 +190,20 @@ type TERCCV1DataSelectionStrategy struct {
 	// Optional fields
 	Tracker string `json:"tracker,omitempty"`
 	URI     string `json:"uri,omitempty"`
+}
+
+// TERCCV1Links represents a slice of TERCCV1Link values with helper methods
+// for adding new links.
+type TERCCV1Links []TERCCV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TERCCV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TERCCV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TERCCV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TERCCV1Link{Target: target, Type: linkType})
 }
 
 type TERCCV1Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
@@ -90,12 +90,38 @@ func (e *TestExecutionRecipeCollectionCreatedV2) String() string {
 }
 
 var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV2{}
+var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestExecutionRecipeCollectionCreatedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestExecutionRecipeCollectionCreatedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestExecutionRecipeCollectionCreatedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestExecutionRecipeCollectionCreatedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestExecutionRecipeCollectionCreatedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestExecutionRecipeCollectionCreatedV2 struct {
 	// Mandatory fields
-	Data  TERCCV2Data   `json:"data"`
-	Links []TERCCV2Link `json:"links"`
-	Meta  TERCCV2Meta   `json:"meta"`
+	Data  TERCCV2Data  `json:"data"`
+	Links TERCCV2Links `json:"links"`
+	Meta  TERCCV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -173,6 +199,20 @@ type TERCCV2DataSelectionStrategy struct {
 	// Optional fields
 	Tracker string `json:"tracker,omitempty"`
 	URI     string `json:"uri,omitempty"`
+}
+
+// TERCCV2Links represents a slice of TERCCV2Link values with helper methods
+// for adding new links.
+type TERCCV2Links []TERCCV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TERCCV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TERCCV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TERCCV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TERCCV2Link{Target: target, Type: linkType})
 }
 
 type TERCCV2Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
@@ -90,12 +90,38 @@ func (e *TestExecutionRecipeCollectionCreatedV3) String() string {
 }
 
 var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV3{}
+var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestExecutionRecipeCollectionCreatedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestExecutionRecipeCollectionCreatedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestExecutionRecipeCollectionCreatedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestExecutionRecipeCollectionCreatedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestExecutionRecipeCollectionCreatedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestExecutionRecipeCollectionCreatedV3 struct {
 	// Mandatory fields
-	Data  TERCCV3Data   `json:"data"`
-	Links []TERCCV3Link `json:"links"`
-	Meta  TERCCV3Meta   `json:"meta"`
+	Data  TERCCV3Data  `json:"data"`
+	Links TERCCV3Links `json:"links"`
+	Meta  TERCCV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -173,6 +199,20 @@ type TERCCV3DataSelectionStrategy struct {
 	// Optional fields
 	Tracker string `json:"tracker,omitempty"`
 	URI     string `json:"uri,omitempty"`
+}
+
+// TERCCV3Links represents a slice of TERCCV3Link values with helper methods
+// for adding new links.
+type TERCCV3Links []TERCCV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TERCCV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TERCCV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TERCCV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TERCCV3Link{Target: target, Type: linkType})
 }
 
 type TERCCV3Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
@@ -90,12 +90,38 @@ func (e *TestExecutionRecipeCollectionCreatedV4) String() string {
 }
 
 var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV4{}
+var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV4{}
+
+// ID returns the value of the meta.id field.
+func (e TestExecutionRecipeCollectionCreatedV4) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestExecutionRecipeCollectionCreatedV4) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestExecutionRecipeCollectionCreatedV4) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestExecutionRecipeCollectionCreatedV4) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestExecutionRecipeCollectionCreatedV4) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestExecutionRecipeCollectionCreatedV4 struct {
 	// Mandatory fields
-	Data  TERCCV4Data   `json:"data"`
-	Links []TERCCV4Link `json:"links"`
-	Meta  TERCCV4Meta   `json:"meta"`
+	Data  TERCCV4Data  `json:"data"`
+	Links TERCCV4Links `json:"links"`
+	Meta  TERCCV4Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -173,6 +199,20 @@ type TERCCV4DataSelectionStrategy struct {
 	// Optional fields
 	Tracker string `json:"tracker,omitempty"`
 	URI     string `json:"uri,omitempty"`
+}
+
+// TERCCV4Links represents a slice of TERCCV4Link values with helper methods
+// for adding new links.
+type TERCCV4Links []TERCCV4Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TERCCV4Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TERCCV4Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TERCCV4Links) AddByID(linkType string, target string) {
+	*links = append(*links, TERCCV4Link{Target: target, Type: linkType})
 }
 
 type TERCCV4Link struct {

--- a/EiffelTestSuiteFinishedEventV1.go
+++ b/EiffelTestSuiteFinishedEventV1.go
@@ -90,12 +90,38 @@ func (e *TestSuiteFinishedV1) String() string {
 }
 
 var _ FieldSetter = &TestSuiteFinishedV1{}
+var _ MetaTeller = &TestSuiteFinishedV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestSuiteFinishedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestSuiteFinishedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestSuiteFinishedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestSuiteFinishedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestSuiteFinishedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestSuiteFinishedV1 struct {
 	// Mandatory fields
-	Data  TSFV1Data   `json:"data"`
-	Links []TSFV1Link `json:"links"`
-	Meta  TSFV1Meta   `json:"meta"`
+	Data  TSFV1Data  `json:"data"`
+	Links TSFV1Links `json:"links"`
+	Meta  TSFV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -153,6 +179,20 @@ type TSFV1DataPersistentLog struct {
 
 	// Optional fields
 
+}
+
+// TSFV1Links represents a slice of TSFV1Link values with helper methods
+// for adding new links.
+type TSFV1Links []TSFV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TSFV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TSFV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TSFV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TSFV1Link{Target: target, Type: linkType})
 }
 
 type TSFV1Link struct {

--- a/EiffelTestSuiteFinishedEventV2.go
+++ b/EiffelTestSuiteFinishedEventV2.go
@@ -90,12 +90,38 @@ func (e *TestSuiteFinishedV2) String() string {
 }
 
 var _ FieldSetter = &TestSuiteFinishedV2{}
+var _ MetaTeller = &TestSuiteFinishedV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestSuiteFinishedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestSuiteFinishedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestSuiteFinishedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestSuiteFinishedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestSuiteFinishedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestSuiteFinishedV2 struct {
 	// Mandatory fields
-	Data  TSFV2Data   `json:"data"`
-	Links []TSFV2Link `json:"links"`
-	Meta  TSFV2Meta   `json:"meta"`
+	Data  TSFV2Data  `json:"data"`
+	Links TSFV2Links `json:"links"`
+	Meta  TSFV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -153,6 +179,20 @@ type TSFV2DataPersistentLog struct {
 
 	// Optional fields
 
+}
+
+// TSFV2Links represents a slice of TSFV2Link values with helper methods
+// for adding new links.
+type TSFV2Links []TSFV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TSFV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TSFV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TSFV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TSFV2Link{Target: target, Type: linkType})
 }
 
 type TSFV2Link struct {

--- a/EiffelTestSuiteFinishedEventV3.go
+++ b/EiffelTestSuiteFinishedEventV3.go
@@ -90,12 +90,38 @@ func (e *TestSuiteFinishedV3) String() string {
 }
 
 var _ FieldSetter = &TestSuiteFinishedV3{}
+var _ MetaTeller = &TestSuiteFinishedV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestSuiteFinishedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestSuiteFinishedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestSuiteFinishedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestSuiteFinishedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestSuiteFinishedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestSuiteFinishedV3 struct {
 	// Mandatory fields
-	Data  TSFV3Data   `json:"data"`
-	Links []TSFV3Link `json:"links"`
-	Meta  TSFV3Meta   `json:"meta"`
+	Data  TSFV3Data  `json:"data"`
+	Links TSFV3Links `json:"links"`
+	Meta  TSFV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -154,6 +180,20 @@ type TSFV3DataPersistentLog struct {
 	// Optional fields
 	MediaType string   `json:"mediaType,omitempty"`
 	Tags      []string `json:"tags,omitempty"`
+}
+
+// TSFV3Links represents a slice of TSFV3Link values with helper methods
+// for adding new links.
+type TSFV3Links []TSFV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TSFV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TSFV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TSFV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TSFV3Link{Target: target, Type: linkType})
 }
 
 type TSFV3Link struct {

--- a/EiffelTestSuiteStartedEventV1.go
+++ b/EiffelTestSuiteStartedEventV1.go
@@ -90,12 +90,38 @@ func (e *TestSuiteStartedV1) String() string {
 }
 
 var _ FieldSetter = &TestSuiteStartedV1{}
+var _ MetaTeller = &TestSuiteStartedV1{}
+
+// ID returns the value of the meta.id field.
+func (e TestSuiteStartedV1) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestSuiteStartedV1) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestSuiteStartedV1) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestSuiteStartedV1) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestSuiteStartedV1) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestSuiteStartedV1 struct {
 	// Mandatory fields
-	Data  TSSV1Data   `json:"data"`
-	Links []TSSV1Link `json:"links"`
-	Meta  TSSV1Meta   `json:"meta"`
+	Data  TSSV1Data  `json:"data"`
+	Links TSSV1Links `json:"links"`
+	Meta  TSSV1Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -151,6 +177,20 @@ const (
 	TSSV1DataType_Stability        TSSV1DataType = "STABILITY"
 	TSSV1DataType_Usability        TSSV1DataType = "USABILITY"
 )
+
+// TSSV1Links represents a slice of TSSV1Link values with helper methods
+// for adding new links.
+type TSSV1Links []TSSV1Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TSSV1Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TSSV1Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TSSV1Links) AddByID(linkType string, target string) {
+	*links = append(*links, TSSV1Link{Target: target, Type: linkType})
+}
 
 type TSSV1Link struct {
 	// Mandatory fields

--- a/EiffelTestSuiteStartedEventV2.go
+++ b/EiffelTestSuiteStartedEventV2.go
@@ -90,12 +90,38 @@ func (e *TestSuiteStartedV2) String() string {
 }
 
 var _ FieldSetter = &TestSuiteStartedV2{}
+var _ MetaTeller = &TestSuiteStartedV2{}
+
+// ID returns the value of the meta.id field.
+func (e TestSuiteStartedV2) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestSuiteStartedV2) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestSuiteStartedV2) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestSuiteStartedV2) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestSuiteStartedV2) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestSuiteStartedV2 struct {
 	// Mandatory fields
-	Data  TSSV2Data   `json:"data"`
-	Links []TSSV2Link `json:"links"`
-	Meta  TSSV2Meta   `json:"meta"`
+	Data  TSSV2Data  `json:"data"`
+	Links TSSV2Links `json:"links"`
+	Meta  TSSV2Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -151,6 +177,20 @@ const (
 	TSSV2DataType_Stability        TSSV2DataType = "STABILITY"
 	TSSV2DataType_Usability        TSSV2DataType = "USABILITY"
 )
+
+// TSSV2Links represents a slice of TSSV2Link values with helper methods
+// for adding new links.
+type TSSV2Links []TSSV2Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TSSV2Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TSSV2Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TSSV2Links) AddByID(linkType string, target string) {
+	*links = append(*links, TSSV2Link{Target: target, Type: linkType})
+}
 
 type TSSV2Link struct {
 	// Mandatory fields

--- a/EiffelTestSuiteStartedEventV3.go
+++ b/EiffelTestSuiteStartedEventV3.go
@@ -90,12 +90,38 @@ func (e *TestSuiteStartedV3) String() string {
 }
 
 var _ FieldSetter = &TestSuiteStartedV3{}
+var _ MetaTeller = &TestSuiteStartedV3{}
+
+// ID returns the value of the meta.id field.
+func (e TestSuiteStartedV3) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e TestSuiteStartedV3) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e TestSuiteStartedV3) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e TestSuiteStartedV3) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e TestSuiteStartedV3) DomainID() string {
+	return e.Meta.Source.DomainID
+}
 
 type TestSuiteStartedV3 struct {
 	// Mandatory fields
-	Data  TSSV3Data   `json:"data"`
-	Links []TSSV3Link `json:"links"`
-	Meta  TSSV3Meta   `json:"meta"`
+	Data  TSSV3Data  `json:"data"`
+	Links TSSV3Links `json:"links"`
+	Meta  TSSV3Meta  `json:"meta"`
 
 	// Optional fields
 
@@ -152,6 +178,20 @@ const (
 	TSSV3DataType_Stability        TSSV3DataType = "STABILITY"
 	TSSV3DataType_Usability        TSSV3DataType = "USABILITY"
 )
+
+// TSSV3Links represents a slice of TSSV3Link values with helper methods
+// for adding new links.
+type TSSV3Links []TSSV3Link
+
+// Add adds a new link of the specified type to a target event.
+func (links *TSSV3Links) Add(linkType string, target MetaTeller) {
+	*links = append(*links, TSSV3Link{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *TSSV3Links) AddByID(linkType string, target string) {
+	*links = append(*links, TSSV3Link{Target: target, Type: linkType})
+}
 
 type TSSV3Link struct {
 	// Mandatory fields

--- a/internal/cmd/eventgen/templates/eventfile.tmpl
+++ b/internal/cmd/eventgen/templates/eventfile.tmpl
@@ -90,3 +90,29 @@ func (e *{{.StructName}}) String() string {
 }
 
 var _ FieldSetter = &{{.StructName}}{}
+var _ MetaTeller = &{{.StructName}}{}
+
+// ID returns the value of the meta.id field.
+func (e {{.StructName}}) ID() string {
+	return e.Meta.ID
+}
+
+// Type returns the value of the meta.type field.
+func (e {{.StructName}}) Type() string {
+	return e.Meta.Type
+}
+
+// Version returns the value of the meta.version field.
+func (e {{.StructName}}) Version() string {
+	return e.Meta.Version
+}
+
+// Time returns the value of the meta.time field.
+func (e {{.StructName}}) Time() int64 {
+	return e.Meta.Time
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (e {{.StructName}}) DomainID() string {
+	return e.Meta.Source.DomainID
+}

--- a/internal/cmd/eventgen/templates/linkslice_decl.tmpl
+++ b/internal/cmd/eventgen/templates/linkslice_decl.tmpl
@@ -1,0 +1,13 @@
+// {{.TypeName}} represents a slice of {{.SlicedType}} values with helper methods
+// for adding new links.
+type {{.TypeName}} []{{.SlicedType}}
+
+// Add adds a new link of the specified type to a target event.
+func (links *{{.TypeName}}) Add(linkType string, target MetaTeller) {
+	*links = append(*links, {{.SlicedType}}{Target: target.ID(), Type: linkType})
+}
+
+// Add adds a new link of the specified type to a target event identified by an ID.
+func (links *{{.TypeName}}) AddByID(linkType string, target string) {
+	*links = append(*links, {{.SlicedType}}{Target: target, Type: linkType})
+}

--- a/metateller.go
+++ b/metateller.go
@@ -1,0 +1,37 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eiffelevents
+
+// MetaTeller allow introspection of key metadata fields of anything that
+// resembles an Eiffel event. Not all meta fields are included since they
+// may vary over time, but is believed to be a time-invariant subset.
+type MetaTeller interface {
+	// ID returns the value of the meta.id field.
+	ID() string
+
+	// Type returns the value of the meta.type field.
+	Type() string
+
+	// Version returns the value of the meta.version field.
+	Version() string
+
+	// Time returns the value of the meta.time field.
+	Time() int64
+
+	// DomainID returns the value of the meta.source.domainId field.
+	DomainID() string
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #17 

### Description of the Change
To make it less tedious to write code that links events we introduce a distinct type of the links field in each event struct. Instead of having the type []XXXLink we now declare a custom type XXXLinks that includes a couple of methods for appending links of the right type to the slice. This allows you to simplify code like

    event.Links = append(event.Links, eiffelevents.ActTV3Link{
            Type:   "CAUSE",
            Target: other.Meta.ID,
    })

to

    event.Links.Add("CAUSE", other)

which not only is a lot shorter but also doesn't include the name of a versioned type, i.e. edition upgrades are less likely to require type reference updates.

To support passing an arbitrary event to the Add method without having to use reflection to locate its meta.id we add a MetaTeller interface that all events implement. The interface contains methods for obtaining basic meta fields, including the event's id.

### Alternate Designs
None.

### Benefits
Cleaner and more maintainable code that populates events with links.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
