### PR TITLE
Add LinkFinder interface with FindFirst and FindAll methods

### DIFF
--- a/EiffelActivityCanceledEventV1.go
+++ b/EiffelActivityCanceledEventV1.go
@@ -148,6 +148,8 @@ type ActCV1DataCustomDatum struct {
 // for adding new links.
 type ActCV1Links []ActCV1Link
 
+var _ LinkFinder = &ActCV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActCV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActCV1Link{Target: target.ID(), Type: linkType})
@@ -156,6 +158,29 @@ func (links *ActCV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActCV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActCV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActCV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActCV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActCV1Link struct {

--- a/EiffelActivityCanceledEventV2.go
+++ b/EiffelActivityCanceledEventV2.go
@@ -148,6 +148,8 @@ type ActCV2DataCustomDatum struct {
 // for adding new links.
 type ActCV2Links []ActCV2Link
 
+var _ LinkFinder = &ActCV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActCV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActCV2Link{Target: target.ID(), Type: linkType})
@@ -156,6 +158,29 @@ func (links *ActCV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActCV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActCV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActCV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActCV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActCV2Link struct {

--- a/EiffelActivityCanceledEventV3.go
+++ b/EiffelActivityCanceledEventV3.go
@@ -148,6 +148,8 @@ type ActCV3DataCustomDatum struct {
 // for adding new links.
 type ActCV3Links []ActCV3Link
 
+var _ LinkFinder = &ActCV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActCV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActCV3Link{Target: target.ID(), Type: linkType})
@@ -156,6 +158,29 @@ func (links *ActCV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActCV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActCV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActCV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActCV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActCV3Link struct {

--- a/EiffelActivityFinishedEventV1.go
+++ b/EiffelActivityFinishedEventV1.go
@@ -177,6 +177,8 @@ type ActFV1DataPersistentLog struct {
 // for adding new links.
 type ActFV1Links []ActFV1Link
 
+var _ LinkFinder = &ActFV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActFV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActFV1Link{Target: target.ID(), Type: linkType})
@@ -185,6 +187,29 @@ func (links *ActFV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActFV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActFV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActFV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActFV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActFV1Link struct {

--- a/EiffelActivityFinishedEventV2.go
+++ b/EiffelActivityFinishedEventV2.go
@@ -177,6 +177,8 @@ type ActFV2DataPersistentLog struct {
 // for adding new links.
 type ActFV2Links []ActFV2Link
 
+var _ LinkFinder = &ActFV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActFV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActFV2Link{Target: target.ID(), Type: linkType})
@@ -185,6 +187,29 @@ func (links *ActFV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActFV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActFV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActFV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActFV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActFV2Link struct {

--- a/EiffelActivityFinishedEventV3.go
+++ b/EiffelActivityFinishedEventV3.go
@@ -178,6 +178,8 @@ type ActFV3DataPersistentLog struct {
 // for adding new links.
 type ActFV3Links []ActFV3Link
 
+var _ LinkFinder = &ActFV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActFV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActFV3Link{Target: target.ID(), Type: linkType})
@@ -186,6 +188,29 @@ func (links *ActFV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActFV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActFV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActFV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActFV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActFV3Link struct {

--- a/EiffelActivityStartedEventV1.go
+++ b/EiffelActivityStartedEventV1.go
@@ -158,6 +158,8 @@ type ActSV1DataLiveLog struct {
 // for adding new links.
 type ActSV1Links []ActSV1Link
 
+var _ LinkFinder = &ActSV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActSV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActSV1Link{Target: target.ID(), Type: linkType})
@@ -166,6 +168,29 @@ func (links *ActSV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActSV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActSV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActSV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActSV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActSV1Link struct {

--- a/EiffelActivityStartedEventV2.go
+++ b/EiffelActivityStartedEventV2.go
@@ -158,6 +158,8 @@ type ActSV2DataLiveLog struct {
 // for adding new links.
 type ActSV2Links []ActSV2Link
 
+var _ LinkFinder = &ActSV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActSV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActSV2Link{Target: target.ID(), Type: linkType})
@@ -166,6 +168,29 @@ func (links *ActSV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActSV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActSV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActSV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActSV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActSV2Link struct {

--- a/EiffelActivityStartedEventV3.go
+++ b/EiffelActivityStartedEventV3.go
@@ -158,6 +158,8 @@ type ActSV3DataLiveLog struct {
 // for adding new links.
 type ActSV3Links []ActSV3Link
 
+var _ LinkFinder = &ActSV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActSV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActSV3Link{Target: target.ID(), Type: linkType})
@@ -166,6 +168,29 @@ func (links *ActSV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActSV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActSV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActSV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActSV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActSV3Link struct {

--- a/EiffelActivityStartedEventV4.go
+++ b/EiffelActivityStartedEventV4.go
@@ -159,6 +159,8 @@ type ActSV4DataLiveLog struct {
 // for adding new links.
 type ActSV4Links []ActSV4Link
 
+var _ LinkFinder = &ActSV4Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActSV4Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActSV4Link{Target: target.ID(), Type: linkType})
@@ -167,6 +169,29 @@ func (links *ActSV4Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActSV4Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActSV4Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActSV4Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActSV4Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActSV4Link struct {

--- a/EiffelActivityTriggeredEventV1.go
+++ b/EiffelActivityTriggeredEventV1.go
@@ -178,6 +178,8 @@ const (
 // for adding new links.
 type ActTV1Links []ActTV1Link
 
+var _ LinkFinder = &ActTV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActTV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActTV1Link{Target: target.ID(), Type: linkType})
@@ -186,6 +188,29 @@ func (links *ActTV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActTV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActTV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActTV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActTV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActTV1Link struct {

--- a/EiffelActivityTriggeredEventV2.go
+++ b/EiffelActivityTriggeredEventV2.go
@@ -178,6 +178,8 @@ const (
 // for adding new links.
 type ActTV2Links []ActTV2Link
 
+var _ LinkFinder = &ActTV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActTV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActTV2Link{Target: target.ID(), Type: linkType})
@@ -186,6 +188,29 @@ func (links *ActTV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActTV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActTV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActTV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActTV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActTV2Link struct {

--- a/EiffelActivityTriggeredEventV3.go
+++ b/EiffelActivityTriggeredEventV3.go
@@ -178,6 +178,8 @@ const (
 // for adding new links.
 type ActTV3Links []ActTV3Link
 
+var _ LinkFinder = &ActTV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActTV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActTV3Link{Target: target.ID(), Type: linkType})
@@ -186,6 +188,29 @@ func (links *ActTV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActTV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActTV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActTV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActTV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActTV3Link struct {

--- a/EiffelActivityTriggeredEventV4.go
+++ b/EiffelActivityTriggeredEventV4.go
@@ -178,6 +178,8 @@ const (
 // for adding new links.
 type ActTV4Links []ActTV4Link
 
+var _ LinkFinder = &ActTV4Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ActTV4Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ActTV4Link{Target: target.ID(), Type: linkType})
@@ -186,6 +188,29 @@ func (links *ActTV4Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ActTV4Links) AddByID(linkType string, target string) {
 	*links = append(*links, ActTV4Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ActTV4Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ActTV4Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ActTV4Link struct {

--- a/EiffelAnnouncementPublishedEventV1.go
+++ b/EiffelAnnouncementPublishedEventV1.go
@@ -162,6 +162,8 @@ const (
 // for adding new links.
 type AnnPV1Links []AnnPV1Link
 
+var _ LinkFinder = &AnnPV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *AnnPV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, AnnPV1Link{Target: target.ID(), Type: linkType})
@@ -170,6 +172,29 @@ func (links *AnnPV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *AnnPV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, AnnPV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links AnnPV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links AnnPV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type AnnPV1Link struct {

--- a/EiffelAnnouncementPublishedEventV2.go
+++ b/EiffelAnnouncementPublishedEventV2.go
@@ -162,6 +162,8 @@ const (
 // for adding new links.
 type AnnPV2Links []AnnPV2Link
 
+var _ LinkFinder = &AnnPV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *AnnPV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, AnnPV2Link{Target: target.ID(), Type: linkType})
@@ -170,6 +172,29 @@ func (links *AnnPV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *AnnPV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, AnnPV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links AnnPV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links AnnPV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type AnnPV2Link struct {

--- a/EiffelAnnouncementPublishedEventV3.go
+++ b/EiffelAnnouncementPublishedEventV3.go
@@ -162,6 +162,8 @@ const (
 // for adding new links.
 type AnnPV3Links []AnnPV3Link
 
+var _ LinkFinder = &AnnPV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *AnnPV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, AnnPV3Link{Target: target.ID(), Type: linkType})
@@ -170,6 +172,29 @@ func (links *AnnPV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *AnnPV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, AnnPV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links AnnPV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links AnnPV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type AnnPV3Link struct {

--- a/EiffelArtifactCreatedEventV1.go
+++ b/EiffelArtifactCreatedEventV1.go
@@ -202,6 +202,8 @@ const (
 // for adding new links.
 type ArtCV1Links []ArtCV1Link
 
+var _ LinkFinder = &ArtCV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtCV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtCV1Link{Target: target.ID(), Type: linkType})
@@ -210,6 +212,29 @@ func (links *ArtCV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtCV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtCV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtCV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtCV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtCV1Link struct {

--- a/EiffelArtifactCreatedEventV2.go
+++ b/EiffelArtifactCreatedEventV2.go
@@ -171,6 +171,8 @@ const (
 // for adding new links.
 type ArtCV2Links []ArtCV2Link
 
+var _ LinkFinder = &ArtCV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtCV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtCV2Link{Target: target.ID(), Type: linkType})
@@ -179,6 +181,29 @@ func (links *ArtCV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtCV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtCV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtCV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtCV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtCV2Link struct {

--- a/EiffelArtifactCreatedEventV3.go
+++ b/EiffelArtifactCreatedEventV3.go
@@ -171,6 +171,8 @@ const (
 // for adding new links.
 type ArtCV3Links []ArtCV3Link
 
+var _ LinkFinder = &ArtCV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtCV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtCV3Link{Target: target.ID(), Type: linkType})
@@ -179,6 +181,29 @@ func (links *ArtCV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtCV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtCV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtCV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtCV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtCV3Link struct {

--- a/EiffelArtifactPublishedEventV1.go
+++ b/EiffelArtifactPublishedEventV1.go
@@ -166,6 +166,8 @@ const (
 // for adding new links.
 type ArtPV1Links []ArtPV1Link
 
+var _ LinkFinder = &ArtPV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtPV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtPV1Link{Target: target.ID(), Type: linkType})
@@ -174,6 +176,29 @@ func (links *ArtPV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtPV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtPV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtPV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtPV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtPV1Link struct {

--- a/EiffelArtifactPublishedEventV2.go
+++ b/EiffelArtifactPublishedEventV2.go
@@ -166,6 +166,8 @@ const (
 // for adding new links.
 type ArtPV2Links []ArtPV2Link
 
+var _ LinkFinder = &ArtPV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtPV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtPV2Link{Target: target.ID(), Type: linkType})
@@ -174,6 +176,29 @@ func (links *ArtPV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtPV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtPV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtPV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtPV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtPV2Link struct {

--- a/EiffelArtifactPublishedEventV3.go
+++ b/EiffelArtifactPublishedEventV3.go
@@ -166,6 +166,8 @@ const (
 // for adding new links.
 type ArtPV3Links []ArtPV3Link
 
+var _ LinkFinder = &ArtPV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtPV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtPV3Link{Target: target.ID(), Type: linkType})
@@ -174,6 +176,29 @@ func (links *ArtPV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtPV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtPV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtPV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtPV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtPV3Link struct {

--- a/EiffelArtifactReusedEventV1.go
+++ b/EiffelArtifactReusedEventV1.go
@@ -147,6 +147,8 @@ type ArtRV1DataCustomDatum struct {
 // for adding new links.
 type ArtRV1Links []ArtRV1Link
 
+var _ LinkFinder = &ArtRV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtRV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtRV1Link{Target: target.ID(), Type: linkType})
@@ -155,6 +157,29 @@ func (links *ArtRV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtRV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtRV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtRV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtRV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtRV1Link struct {

--- a/EiffelArtifactReusedEventV2.go
+++ b/EiffelArtifactReusedEventV2.go
@@ -147,6 +147,8 @@ type ArtRV2DataCustomDatum struct {
 // for adding new links.
 type ArtRV2Links []ArtRV2Link
 
+var _ LinkFinder = &ArtRV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtRV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtRV2Link{Target: target.ID(), Type: linkType})
@@ -155,6 +157,29 @@ func (links *ArtRV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtRV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtRV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtRV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtRV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtRV2Link struct {

--- a/EiffelArtifactReusedEventV3.go
+++ b/EiffelArtifactReusedEventV3.go
@@ -147,6 +147,8 @@ type ArtRV3DataCustomDatum struct {
 // for adding new links.
 type ArtRV3Links []ArtRV3Link
 
+var _ LinkFinder = &ArtRV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *ArtRV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, ArtRV3Link{Target: target.ID(), Type: linkType})
@@ -155,6 +157,29 @@ func (links *ArtRV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *ArtRV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, ArtRV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links ArtRV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links ArtRV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type ArtRV3Link struct {

--- a/EiffelCompositionDefinedEventV1.go
+++ b/EiffelCompositionDefinedEventV1.go
@@ -149,6 +149,8 @@ type CDV1DataCustomDatum struct {
 // for adding new links.
 type CDV1Links []CDV1Link
 
+var _ LinkFinder = &CDV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *CDV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, CDV1Link{Target: target.ID(), Type: linkType})
@@ -157,6 +159,29 @@ func (links *CDV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *CDV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, CDV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links CDV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links CDV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type CDV1Link struct {

--- a/EiffelCompositionDefinedEventV2.go
+++ b/EiffelCompositionDefinedEventV2.go
@@ -149,6 +149,8 @@ type CDV2DataCustomDatum struct {
 // for adding new links.
 type CDV2Links []CDV2Link
 
+var _ LinkFinder = &CDV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *CDV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, CDV2Link{Target: target.ID(), Type: linkType})
@@ -157,6 +159,29 @@ func (links *CDV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *CDV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, CDV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links CDV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links CDV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type CDV2Link struct {

--- a/EiffelCompositionDefinedEventV3.go
+++ b/EiffelCompositionDefinedEventV3.go
@@ -149,6 +149,8 @@ type CDV3DataCustomDatum struct {
 // for adding new links.
 type CDV3Links []CDV3Link
 
+var _ LinkFinder = &CDV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *CDV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, CDV3Link{Target: target.ID(), Type: linkType})
@@ -157,6 +159,29 @@ func (links *CDV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *CDV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, CDV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links CDV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links CDV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type CDV3Link struct {

--- a/EiffelConfidenceLevelModifiedEventV1.go
+++ b/EiffelConfidenceLevelModifiedEventV1.go
@@ -168,6 +168,8 @@ const (
 // for adding new links.
 type CLMV1Links []CLMV1Link
 
+var _ LinkFinder = &CLMV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *CLMV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, CLMV1Link{Target: target.ID(), Type: linkType})
@@ -176,6 +178,29 @@ func (links *CLMV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *CLMV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, CLMV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links CLMV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links CLMV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type CLMV1Link struct {

--- a/EiffelConfidenceLevelModifiedEventV2.go
+++ b/EiffelConfidenceLevelModifiedEventV2.go
@@ -168,6 +168,8 @@ const (
 // for adding new links.
 type CLMV2Links []CLMV2Link
 
+var _ LinkFinder = &CLMV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *CLMV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, CLMV2Link{Target: target.ID(), Type: linkType})
@@ -176,6 +178,29 @@ func (links *CLMV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *CLMV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, CLMV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links CLMV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links CLMV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type CLMV2Link struct {

--- a/EiffelConfidenceLevelModifiedEventV3.go
+++ b/EiffelConfidenceLevelModifiedEventV3.go
@@ -168,6 +168,8 @@ const (
 // for adding new links.
 type CLMV3Links []CLMV3Link
 
+var _ LinkFinder = &CLMV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *CLMV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, CLMV3Link{Target: target.ID(), Type: linkType})
@@ -176,6 +178,29 @@ func (links *CLMV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *CLMV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, CLMV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links CLMV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links CLMV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type CLMV3Link struct {

--- a/EiffelEnvironmentDefinedEventV1.go
+++ b/EiffelEnvironmentDefinedEventV1.go
@@ -161,6 +161,8 @@ type EDV1DataHost struct {
 // for adding new links.
 type EDV1Links []EDV1Link
 
+var _ LinkFinder = &EDV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *EDV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, EDV1Link{Target: target.ID(), Type: linkType})
@@ -169,6 +171,29 @@ func (links *EDV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *EDV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, EDV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links EDV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links EDV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type EDV1Link struct {

--- a/EiffelEnvironmentDefinedEventV2.go
+++ b/EiffelEnvironmentDefinedEventV2.go
@@ -161,6 +161,8 @@ type EDV2DataHost struct {
 // for adding new links.
 type EDV2Links []EDV2Link
 
+var _ LinkFinder = &EDV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *EDV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, EDV2Link{Target: target.ID(), Type: linkType})
@@ -169,6 +171,29 @@ func (links *EDV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *EDV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, EDV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links EDV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links EDV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type EDV2Link struct {

--- a/EiffelEnvironmentDefinedEventV3.go
+++ b/EiffelEnvironmentDefinedEventV3.go
@@ -161,6 +161,8 @@ type EDV3DataHost struct {
 // for adding new links.
 type EDV3Links []EDV3Link
 
+var _ LinkFinder = &EDV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *EDV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, EDV3Link{Target: target.ID(), Type: linkType})
@@ -169,6 +171,29 @@ func (links *EDV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *EDV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, EDV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links EDV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links EDV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type EDV3Link struct {

--- a/EiffelFlowContextDefinedEventV1.go
+++ b/EiffelFlowContextDefinedEventV1.go
@@ -152,6 +152,8 @@ type FCDV1DataCustomDatum struct {
 // for adding new links.
 type FCDV1Links []FCDV1Link
 
+var _ LinkFinder = &FCDV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *FCDV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, FCDV1Link{Target: target.ID(), Type: linkType})
@@ -160,6 +162,29 @@ func (links *FCDV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *FCDV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, FCDV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links FCDV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links FCDV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type FCDV1Link struct {

--- a/EiffelFlowContextDefinedEventV2.go
+++ b/EiffelFlowContextDefinedEventV2.go
@@ -152,6 +152,8 @@ type FCDV2DataCustomDatum struct {
 // for adding new links.
 type FCDV2Links []FCDV2Link
 
+var _ LinkFinder = &FCDV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *FCDV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, FCDV2Link{Target: target.ID(), Type: linkType})
@@ -160,6 +162,29 @@ func (links *FCDV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *FCDV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, FCDV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links FCDV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links FCDV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type FCDV2Link struct {

--- a/EiffelFlowContextDefinedEventV3.go
+++ b/EiffelFlowContextDefinedEventV3.go
@@ -152,6 +152,8 @@ type FCDV3DataCustomDatum struct {
 // for adding new links.
 type FCDV3Links []FCDV3Link
 
+var _ LinkFinder = &FCDV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *FCDV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, FCDV3Link{Target: target.ID(), Type: linkType})
@@ -160,6 +162,29 @@ func (links *FCDV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *FCDV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, FCDV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links FCDV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links FCDV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type FCDV3Link struct {

--- a/EiffelIssueDefinedEventV1.go
+++ b/EiffelIssueDefinedEventV1.go
@@ -162,6 +162,8 @@ const (
 // for adding new links.
 type IDV1Links []IDV1Link
 
+var _ LinkFinder = &IDV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IDV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IDV1Link{Target: target.ID(), Type: linkType})
@@ -170,6 +172,29 @@ func (links *IDV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IDV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, IDV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IDV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IDV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IDV1Link struct {

--- a/EiffelIssueDefinedEventV2.go
+++ b/EiffelIssueDefinedEventV2.go
@@ -162,6 +162,8 @@ const (
 // for adding new links.
 type IDV2Links []IDV2Link
 
+var _ LinkFinder = &IDV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IDV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IDV2Link{Target: target.ID(), Type: linkType})
@@ -170,6 +172,29 @@ func (links *IDV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IDV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, IDV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IDV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IDV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IDV2Link struct {

--- a/EiffelIssueDefinedEventV3.go
+++ b/EiffelIssueDefinedEventV3.go
@@ -162,6 +162,8 @@ const (
 // for adding new links.
 type IDV3Links []IDV3Link
 
+var _ LinkFinder = &IDV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IDV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IDV3Link{Target: target.ID(), Type: linkType})
@@ -170,6 +172,29 @@ func (links *IDV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IDV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, IDV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IDV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IDV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IDV3Link struct {

--- a/EiffelIssueVerifiedEventV1.go
+++ b/EiffelIssueVerifiedEventV1.go
@@ -179,6 +179,8 @@ const (
 // for adding new links.
 type IVV1Links []IVV1Link
 
+var _ LinkFinder = &IVV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IVV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IVV1Link{Target: target.ID(), Type: linkType})
@@ -187,6 +189,29 @@ func (links *IVV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IVV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, IVV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IVV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IVV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IVV1Link struct {

--- a/EiffelIssueVerifiedEventV2.go
+++ b/EiffelIssueVerifiedEventV2.go
@@ -147,6 +147,8 @@ type IVV2DataCustomDatum struct {
 // for adding new links.
 type IVV2Links []IVV2Link
 
+var _ LinkFinder = &IVV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IVV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IVV2Link{Target: target.ID(), Type: linkType})
@@ -155,6 +157,29 @@ func (links *IVV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IVV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, IVV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IVV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IVV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IVV2Link struct {

--- a/EiffelIssueVerifiedEventV3.go
+++ b/EiffelIssueVerifiedEventV3.go
@@ -147,6 +147,8 @@ type IVV3DataCustomDatum struct {
 // for adding new links.
 type IVV3Links []IVV3Link
 
+var _ LinkFinder = &IVV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IVV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IVV3Link{Target: target.ID(), Type: linkType})
@@ -155,6 +157,29 @@ func (links *IVV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IVV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, IVV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IVV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IVV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IVV3Link struct {

--- a/EiffelIssueVerifiedEventV4.go
+++ b/EiffelIssueVerifiedEventV4.go
@@ -147,6 +147,8 @@ type IVV4DataCustomDatum struct {
 // for adding new links.
 type IVV4Links []IVV4Link
 
+var _ LinkFinder = &IVV4Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *IVV4Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, IVV4Link{Target: target.ID(), Type: linkType})
@@ -155,6 +157,29 @@ func (links *IVV4Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *IVV4Links) AddByID(linkType string, target string) {
 	*links = append(*links, IVV4Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links IVV4Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links IVV4Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type IVV4Link struct {

--- a/EiffelSourceChangeCreatedEventV1.go
+++ b/EiffelSourceChangeCreatedEventV1.go
@@ -216,6 +216,8 @@ type SCCV1DataSvnIdentifier struct {
 // for adding new links.
 type SCCV1Links []SCCV1Link
 
+var _ LinkFinder = &SCCV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCCV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCCV1Link{Target: target.ID(), Type: linkType})
@@ -224,6 +226,29 @@ func (links *SCCV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCCV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCCV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCCV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCCV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCCV1Link struct {

--- a/EiffelSourceChangeCreatedEventV2.go
+++ b/EiffelSourceChangeCreatedEventV2.go
@@ -215,6 +215,8 @@ type SCCV2DataSvnIdentifier struct {
 // for adding new links.
 type SCCV2Links []SCCV2Link
 
+var _ LinkFinder = &SCCV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCCV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCCV2Link{Target: target.ID(), Type: linkType})
@@ -223,6 +225,29 @@ func (links *SCCV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCCV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCCV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCCV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCCV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCCV2Link struct {

--- a/EiffelSourceChangeCreatedEventV3.go
+++ b/EiffelSourceChangeCreatedEventV3.go
@@ -215,6 +215,8 @@ type SCCV3DataSvnIdentifier struct {
 // for adding new links.
 type SCCV3Links []SCCV3Link
 
+var _ LinkFinder = &SCCV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCCV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCCV3Link{Target: target.ID(), Type: linkType})
@@ -223,6 +225,29 @@ func (links *SCCV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCCV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCCV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCCV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCCV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCCV3Link struct {

--- a/EiffelSourceChangeCreatedEventV4.go
+++ b/EiffelSourceChangeCreatedEventV4.go
@@ -215,6 +215,8 @@ type SCCV4DataSvnIdentifier struct {
 // for adding new links.
 type SCCV4Links []SCCV4Link
 
+var _ LinkFinder = &SCCV4Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCCV4Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCCV4Link{Target: target.ID(), Type: linkType})
@@ -223,6 +225,29 @@ func (links *SCCV4Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCCV4Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCCV4Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCCV4Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCCV4Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCCV4Link struct {

--- a/EiffelSourceChangeSubmittedEventV1.go
+++ b/EiffelSourceChangeSubmittedEventV1.go
@@ -202,6 +202,8 @@ type SCSV1DataSvnIdentifier struct {
 // for adding new links.
 type SCSV1Links []SCSV1Link
 
+var _ LinkFinder = &SCSV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCSV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCSV1Link{Target: target.ID(), Type: linkType})
@@ -210,6 +212,29 @@ func (links *SCSV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCSV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCSV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCSV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCSV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCSV1Link struct {

--- a/EiffelSourceChangeSubmittedEventV2.go
+++ b/EiffelSourceChangeSubmittedEventV2.go
@@ -202,6 +202,8 @@ type SCSV2DataSvnIdentifier struct {
 // for adding new links.
 type SCSV2Links []SCSV2Link
 
+var _ LinkFinder = &SCSV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCSV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCSV2Link{Target: target.ID(), Type: linkType})
@@ -210,6 +212,29 @@ func (links *SCSV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCSV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCSV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCSV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCSV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCSV2Link struct {

--- a/EiffelSourceChangeSubmittedEventV3.go
+++ b/EiffelSourceChangeSubmittedEventV3.go
@@ -202,6 +202,8 @@ type SCSV3DataSvnIdentifier struct {
 // for adding new links.
 type SCSV3Links []SCSV3Link
 
+var _ LinkFinder = &SCSV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *SCSV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, SCSV3Link{Target: target.ID(), Type: linkType})
@@ -210,6 +212,29 @@ func (links *SCSV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *SCSV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, SCSV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links SCSV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links SCSV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type SCSV3Link struct {

--- a/EiffelTestCaseCanceledEventV1.go
+++ b/EiffelTestCaseCanceledEventV1.go
@@ -148,6 +148,8 @@ type TCCV1DataCustomDatum struct {
 // for adding new links.
 type TCCV1Links []TCCV1Link
 
+var _ LinkFinder = &TCCV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCCV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCCV1Link{Target: target.ID(), Type: linkType})
@@ -156,6 +158,29 @@ func (links *TCCV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCCV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCCV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCCV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCCV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCCV1Link struct {

--- a/EiffelTestCaseCanceledEventV2.go
+++ b/EiffelTestCaseCanceledEventV2.go
@@ -148,6 +148,8 @@ type TCCV2DataCustomDatum struct {
 // for adding new links.
 type TCCV2Links []TCCV2Link
 
+var _ LinkFinder = &TCCV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCCV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCCV2Link{Target: target.ID(), Type: linkType})
@@ -156,6 +158,29 @@ func (links *TCCV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCCV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCCV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCCV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCCV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCCV2Link struct {

--- a/EiffelTestCaseCanceledEventV3.go
+++ b/EiffelTestCaseCanceledEventV3.go
@@ -148,6 +148,8 @@ type TCCV3DataCustomDatum struct {
 // for adding new links.
 type TCCV3Links []TCCV3Link
 
+var _ LinkFinder = &TCCV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCCV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCCV3Link{Target: target.ID(), Type: linkType})
@@ -156,6 +158,29 @@ func (links *TCCV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCCV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCCV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCCV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCCV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCCV3Link struct {

--- a/EiffelTestCaseFinishedEventV1.go
+++ b/EiffelTestCaseFinishedEventV1.go
@@ -195,6 +195,8 @@ type TCFV1DataPersistentLog struct {
 // for adding new links.
 type TCFV1Links []TCFV1Link
 
+var _ LinkFinder = &TCFV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCFV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCFV1Link{Target: target.ID(), Type: linkType})
@@ -203,6 +205,29 @@ func (links *TCFV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCFV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCFV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCFV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCFV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCFV1Link struct {

--- a/EiffelTestCaseFinishedEventV2.go
+++ b/EiffelTestCaseFinishedEventV2.go
@@ -195,6 +195,8 @@ type TCFV2DataPersistentLog struct {
 // for adding new links.
 type TCFV2Links []TCFV2Link
 
+var _ LinkFinder = &TCFV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCFV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCFV2Link{Target: target.ID(), Type: linkType})
@@ -203,6 +205,29 @@ func (links *TCFV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCFV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCFV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCFV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCFV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCFV2Link struct {

--- a/EiffelTestCaseFinishedEventV3.go
+++ b/EiffelTestCaseFinishedEventV3.go
@@ -196,6 +196,8 @@ type TCFV3DataPersistentLog struct {
 // for adding new links.
 type TCFV3Links []TCFV3Link
 
+var _ LinkFinder = &TCFV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCFV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCFV3Link{Target: target.ID(), Type: linkType})
@@ -204,6 +206,29 @@ func (links *TCFV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCFV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCFV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCFV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCFV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCFV3Link struct {

--- a/EiffelTestCaseStartedEventV1.go
+++ b/EiffelTestCaseStartedEventV1.go
@@ -158,6 +158,8 @@ type TCSV1DataLiveLog struct {
 // for adding new links.
 type TCSV1Links []TCSV1Link
 
+var _ LinkFinder = &TCSV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCSV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCSV1Link{Target: target.ID(), Type: linkType})
@@ -166,6 +168,29 @@ func (links *TCSV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCSV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCSV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCSV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCSV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCSV1Link struct {

--- a/EiffelTestCaseStartedEventV2.go
+++ b/EiffelTestCaseStartedEventV2.go
@@ -158,6 +158,8 @@ type TCSV2DataLiveLog struct {
 // for adding new links.
 type TCSV2Links []TCSV2Link
 
+var _ LinkFinder = &TCSV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCSV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCSV2Link{Target: target.ID(), Type: linkType})
@@ -166,6 +168,29 @@ func (links *TCSV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCSV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCSV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCSV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCSV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCSV2Link struct {

--- a/EiffelTestCaseStartedEventV3.go
+++ b/EiffelTestCaseStartedEventV3.go
@@ -159,6 +159,8 @@ type TCSV3DataLiveLog struct {
 // for adding new links.
 type TCSV3Links []TCSV3Link
 
+var _ LinkFinder = &TCSV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCSV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCSV3Link{Target: target.ID(), Type: linkType})
@@ -167,6 +169,29 @@ func (links *TCSV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCSV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCSV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCSV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCSV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCSV3Link struct {

--- a/EiffelTestCaseTriggeredEventV1.go
+++ b/EiffelTestCaseTriggeredEventV1.go
@@ -198,6 +198,8 @@ const (
 // for adding new links.
 type TCTV1Links []TCTV1Link
 
+var _ LinkFinder = &TCTV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCTV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCTV1Link{Target: target.ID(), Type: linkType})
@@ -206,6 +208,29 @@ func (links *TCTV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCTV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCTV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCTV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCTV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCTV1Link struct {

--- a/EiffelTestCaseTriggeredEventV2.go
+++ b/EiffelTestCaseTriggeredEventV2.go
@@ -198,6 +198,8 @@ const (
 // for adding new links.
 type TCTV2Links []TCTV2Link
 
+var _ LinkFinder = &TCTV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCTV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCTV2Link{Target: target.ID(), Type: linkType})
@@ -206,6 +208,29 @@ func (links *TCTV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCTV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCTV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCTV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCTV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCTV2Link struct {

--- a/EiffelTestCaseTriggeredEventV3.go
+++ b/EiffelTestCaseTriggeredEventV3.go
@@ -198,6 +198,8 @@ const (
 // for adding new links.
 type TCTV3Links []TCTV3Link
 
+var _ LinkFinder = &TCTV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TCTV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TCTV3Link{Target: target.ID(), Type: linkType})
@@ -206,6 +208,29 @@ func (links *TCTV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TCTV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TCTV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TCTV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TCTV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TCTV3Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
@@ -196,6 +196,8 @@ type TERCCV1DataSelectionStrategy struct {
 // for adding new links.
 type TERCCV1Links []TERCCV1Link
 
+var _ LinkFinder = &TERCCV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TERCCV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TERCCV1Link{Target: target.ID(), Type: linkType})
@@ -204,6 +206,29 @@ func (links *TERCCV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TERCCV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TERCCV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TERCCV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TERCCV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TERCCV1Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
@@ -205,6 +205,8 @@ type TERCCV2DataSelectionStrategy struct {
 // for adding new links.
 type TERCCV2Links []TERCCV2Link
 
+var _ LinkFinder = &TERCCV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TERCCV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TERCCV2Link{Target: target.ID(), Type: linkType})
@@ -213,6 +215,29 @@ func (links *TERCCV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TERCCV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TERCCV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TERCCV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TERCCV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TERCCV2Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
@@ -205,6 +205,8 @@ type TERCCV3DataSelectionStrategy struct {
 // for adding new links.
 type TERCCV3Links []TERCCV3Link
 
+var _ LinkFinder = &TERCCV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TERCCV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TERCCV3Link{Target: target.ID(), Type: linkType})
@@ -213,6 +215,29 @@ func (links *TERCCV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TERCCV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TERCCV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TERCCV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TERCCV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TERCCV3Link struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
@@ -205,6 +205,8 @@ type TERCCV4DataSelectionStrategy struct {
 // for adding new links.
 type TERCCV4Links []TERCCV4Link
 
+var _ LinkFinder = &TERCCV4Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TERCCV4Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TERCCV4Link{Target: target.ID(), Type: linkType})
@@ -213,6 +215,29 @@ func (links *TERCCV4Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TERCCV4Links) AddByID(linkType string, target string) {
 	*links = append(*links, TERCCV4Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TERCCV4Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TERCCV4Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TERCCV4Link struct {

--- a/EiffelTestSuiteFinishedEventV1.go
+++ b/EiffelTestSuiteFinishedEventV1.go
@@ -185,6 +185,8 @@ type TSFV1DataPersistentLog struct {
 // for adding new links.
 type TSFV1Links []TSFV1Link
 
+var _ LinkFinder = &TSFV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TSFV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TSFV1Link{Target: target.ID(), Type: linkType})
@@ -193,6 +195,29 @@ func (links *TSFV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TSFV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TSFV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TSFV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TSFV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TSFV1Link struct {

--- a/EiffelTestSuiteFinishedEventV2.go
+++ b/EiffelTestSuiteFinishedEventV2.go
@@ -185,6 +185,8 @@ type TSFV2DataPersistentLog struct {
 // for adding new links.
 type TSFV2Links []TSFV2Link
 
+var _ LinkFinder = &TSFV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TSFV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TSFV2Link{Target: target.ID(), Type: linkType})
@@ -193,6 +195,29 @@ func (links *TSFV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TSFV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TSFV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TSFV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TSFV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TSFV2Link struct {

--- a/EiffelTestSuiteFinishedEventV3.go
+++ b/EiffelTestSuiteFinishedEventV3.go
@@ -186,6 +186,8 @@ type TSFV3DataPersistentLog struct {
 // for adding new links.
 type TSFV3Links []TSFV3Link
 
+var _ LinkFinder = &TSFV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TSFV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TSFV3Link{Target: target.ID(), Type: linkType})
@@ -194,6 +196,29 @@ func (links *TSFV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TSFV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TSFV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TSFV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TSFV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TSFV3Link struct {

--- a/EiffelTestSuiteStartedEventV1.go
+++ b/EiffelTestSuiteStartedEventV1.go
@@ -182,6 +182,8 @@ const (
 // for adding new links.
 type TSSV1Links []TSSV1Link
 
+var _ LinkFinder = &TSSV1Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TSSV1Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TSSV1Link{Target: target.ID(), Type: linkType})
@@ -190,6 +192,29 @@ func (links *TSSV1Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TSSV1Links) AddByID(linkType string, target string) {
 	*links = append(*links, TSSV1Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TSSV1Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TSSV1Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TSSV1Link struct {

--- a/EiffelTestSuiteStartedEventV2.go
+++ b/EiffelTestSuiteStartedEventV2.go
@@ -182,6 +182,8 @@ const (
 // for adding new links.
 type TSSV2Links []TSSV2Link
 
+var _ LinkFinder = &TSSV2Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TSSV2Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TSSV2Link{Target: target.ID(), Type: linkType})
@@ -190,6 +192,29 @@ func (links *TSSV2Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TSSV2Links) AddByID(linkType string, target string) {
 	*links = append(*links, TSSV2Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TSSV2Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TSSV2Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TSSV2Link struct {

--- a/EiffelTestSuiteStartedEventV3.go
+++ b/EiffelTestSuiteStartedEventV3.go
@@ -183,6 +183,8 @@ const (
 // for adding new links.
 type TSSV3Links []TSSV3Link
 
+var _ LinkFinder = &TSSV3Links{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *TSSV3Links) Add(linkType string, target MetaTeller) {
 	*links = append(*links, TSSV3Link{Target: target.ID(), Type: linkType})
@@ -191,6 +193,29 @@ func (links *TSSV3Links) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *TSSV3Links) AddByID(linkType string, target string) {
 	*links = append(*links, TSSV3Link{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links TSSV3Links) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links TSSV3Links) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }
 
 type TSSV3Link struct {

--- a/events_test.go
+++ b/events_test.go
@@ -103,3 +103,103 @@ func TestFactoriesWithModifiers(t *testing.T) {
 	_, err = NewActivityTriggeredV3(func(fieldSetter FieldSetter) error { return modifierError })
 	assert.ErrorIs(t, err, modifierError)
 }
+
+// TestLinksFindAll tests the functionaltiy of the generated FindAll method
+// for one of the XXXLinks types.
+func TestLinksFindAll(t *testing.T) {
+	testcases := []struct {
+		name     string
+		links    ActTV3Links
+		wanted   string
+		expected []string
+	}{
+		{
+			"Empty list of links",
+			ActTV3Links{},
+			"CAUSE",
+			[]string{},
+		},
+		{
+			"Single matching link",
+			ActTV3Links{
+				ActTV3Link{"context id", "CONTEXT"},
+				ActTV3Link{"cause id", "CAUSE"},
+			},
+			"CAUSE",
+			[]string{"cause id"},
+		},
+		{
+			"No matching links",
+			ActTV3Links{
+				ActTV3Link{"context id", "CONTEXT"},
+			},
+			"CAUSE",
+			[]string{},
+		},
+		{
+			"Returns all matching links",
+			ActTV3Links{
+				ActTV3Link{"cause id 1", "CAUSE"},
+				ActTV3Link{"context id", "CONTEXT"},
+				ActTV3Link{"cause id 2", "CAUSE"},
+			},
+			"CAUSE",
+			[]string{"cause id 1", "cause id 2"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.links.FindAll(tc.wanted))
+		})
+	}
+}
+
+// TestLinksFindFirst tests the functionaltiy of the generated FindFirst method
+// for one of the XXXLinks types.
+func TestLinksFindFirst(t *testing.T) {
+	testcases := []struct {
+		name     string
+		links    ActTV3Links
+		wanted   string
+		expected string
+	}{
+		{
+			"Empty list of links",
+			ActTV3Links{},
+			"CAUSE",
+			"",
+		},
+		{
+			"Single matching link",
+			ActTV3Links{
+				ActTV3Link{"context id", "CONTEXT"},
+				ActTV3Link{"cause id", "CAUSE"},
+			},
+			"CAUSE",
+			"cause id",
+		},
+		{
+			"No matching links",
+			ActTV3Links{
+				ActTV3Link{"context id", "CONTEXT"},
+			},
+			"CAUSE",
+			"",
+		},
+		{
+			"Returns first of multiple matching links",
+			ActTV3Links{
+				ActTV3Link{"cause id 1", "CAUSE"},
+				ActTV3Link{"context id", "CONTEXT"},
+				ActTV3Link{"cause id 2", "CAUSE"},
+			},
+			"CAUSE",
+			"cause id 1",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.links.FindFirst(tc.wanted))
+		})
+	}
+}

--- a/internal/cmd/eventgen/templates/linkslice_decl.tmpl
+++ b/internal/cmd/eventgen/templates/linkslice_decl.tmpl
@@ -2,6 +2,8 @@
 // for adding new links.
 type {{.TypeName}} []{{.SlicedType}}
 
+var _ LinkFinder = &{{.TypeName}}{}
+
 // Add adds a new link of the specified type to a target event.
 func (links *{{.TypeName}}) Add(linkType string, target MetaTeller) {
 	*links = append(*links, {{.SlicedType}}{Target: target.ID(), Type: linkType})
@@ -10,4 +12,27 @@ func (links *{{.TypeName}}) Add(linkType string, target MetaTeller) {
 // Add adds a new link of the specified type to a target event identified by an ID.
 func (links *{{.TypeName}}) AddByID(linkType string, target string) {
 	*links = append(*links, {{.SlicedType}}{Target: target, Type: linkType})
+}
+
+// FindAll returns the IDs of all links of the specified type, or an empty
+// slice if no such links are found.
+func (links {{.TypeName}}) FindAll(linkType string) []string {
+	result := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Type == linkType {
+			result = append(result, link.Target)
+		}
+	}
+	return result
+}
+
+// FindFirst returns the ID of the first encountered link of the specified
+// type, or an empty string if no such link is found.
+func (links {{.TypeName}}) FindFirst(linkType string) string {
+	for _, link := range links {
+		if link.Type == linkType {
+			return link.Target
+		}
+	}
+	return ""
 }

--- a/linkfinder.go
+++ b/linkfinder.go
@@ -1,0 +1,29 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eiffelevents
+
+// LinkFinder can search through a collection of links and locate those
+// that have a wanted type.
+type LinkFinder interface {
+	// FindAll returns the IDs of all links of the specified type,
+	// or an empty slice if no such links are found.
+	FindAll(linkType string) []string
+
+	// FindFirst returns the ID of the first encountered link of the
+	// specified type, or an empty string if no such link is found.
+	FindFirst(linkType string) string
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #20 

### Description of the Change
The methods in the new LinkFinder interface are added to all XXXLinks types and they can be used as shorthands to locate links of a particular type in the full set of links for an event. While the code for doing the search is trivial it's not reusable between different XXXLinks types so these methods should be useful to consumers of multiple event types.

### Alternate Designs
Considered making the event types themselves also implement LinkFinder (and just proxy to self.Links.FindXXX) but figured that we'd want to have more qualified method names (FindFirstLink etc). Decided to punt.

Also considered returning not just the target IDs but also the corresponding domain IDs but it was unclear how to do that in a nice way given that only Lyon events even have that attribute. There's a risk that these short-form helpers would bloat and not actually become so convenient.

### Benefits
Convenience for SDK clients.

### Possible Drawbacks
Probably none. I worry a little bit that we'll get into convenience bloat / feature creep. As long as we realize that before v1.0 and can devise something better 

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
