### PR TITLE
Add Any type to allow JSON unmarshaling of compound data structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,48 @@ func main() {
 }
 ```
 
+If you have a compound JSON structure containing e.g. an array of event
+objects you can declare its type to be []*eiffelevents.Any. After unmarshaling
+the data you can use a type switch to process the events:
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/eiffel-community/eiffelevents-sdk-go"
+)
+
+func main() {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+
+	var apiResponse struct {
+		Events []*eiffelevents.Any `json:"events"`
+	}
+
+	err = json.Unmarshal(input, &apiResponse)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, anyEvent := range apiResponse.Events {
+		switch event := anyEvent.Get().(type) {
+		case *eiffelevents.CompositionDefinedV3:
+			fmt.Printf("Received %s composition\n", event.Data.Name)
+		default:
+			fmt.Printf("This event I don't know much about: %s\n", event)
+		}
+	}
+}
+```
+
 ## Code of Conduct and Contributing
 To get involved, please see [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/eiffel-community/.github/blob/master/CONTRIBUTING.md).
 

--- a/any.go
+++ b/any.go
@@ -1,0 +1,98 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eiffelevents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Any is a struct that represents any Eiffel event value. Its intended use is
+// to allow JSON objects with arrays of Eiffel events to be unmarshalled into
+// something useful.
+//
+// The type also implements the MetaTeller interface so if you only need e.g.
+// the ID of each event in a slice you don't have to do a type assertion on
+// every element.
+type Any struct {
+	event interface{}
+}
+
+var (
+	_ MetaTeller       = &Any{}
+	_ json.Marshaler   = &Any{}
+	_ json.Unmarshaler = &Any{}
+)
+
+// Get obtains the event as an interface pointer. Use a type assertion to
+// convert it to a concrete event struct pointer.
+func (a Any) Get() interface{} {
+	return a.event
+}
+
+// MarshalJSON converts the event to its JSON representation.
+func (a Any) MarshalJSON() ([]byte, error) {
+	if v, ok := a.event.(json.Marshaler); ok {
+		return v.MarshalJSON()
+	}
+	return nil, errors.New("value not marshalable as JSON")
+}
+
+// UnmarshalJSON parses the byte slice input as JSON and stores it.
+func (a *Any) UnmarshalJSON(b []byte) error {
+	var err error
+	a.event, err = UnmarshalAny(b)
+	if err != nil {
+		return err
+	}
+
+	// These checks are probably unnecessary since UnmarshalAny is pretty
+	// picky about what it accepts.
+	if _, ok := a.event.(FieldSetter); !ok {
+		return fmt.Errorf("unmarshaling did not produce an Eiffel event: %w", err)
+	}
+	if _, ok := a.event.(MetaTeller); !ok {
+		return fmt.Errorf("unmarshaling did not produce an Eiffel event: %w", err)
+	}
+	return nil
+}
+
+// ID returns the value of the meta.id field.
+func (a Any) ID() string {
+	return a.event.(MetaTeller).ID()
+}
+
+// Type returns the value of the meta.type field.
+func (a Any) Type() string {
+	return a.event.(MetaTeller).Type()
+}
+
+// Version returns the value of the meta.version field.
+func (a Any) Version() string {
+	return a.event.(MetaTeller).Version()
+}
+
+// Time returns the value of the meta.time field.
+func (a Any) Time() int64 {
+	return a.event.(MetaTeller).Time()
+}
+
+// DomainID returns the value of the meta.source.domainId field.
+func (a Any) DomainID() string {
+	return a.event.(MetaTeller).DomainID()
+}

--- a/any_test.go
+++ b/any_test.go
@@ -1,0 +1,114 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eiffelevents
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ExampleAny() {
+	inputData := `
+	[
+	  {
+	    "meta": {
+	      "type": "EiffelCompositionDefinedEvent",
+	      "version": "3.2.0",
+	      "time": 1234567890,
+	      "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
+	    },
+	    "data": {
+	      "name": "My Composition"
+	    },
+	    "links": []
+	  }
+	]`
+	var eventSlice []*Any
+	_ = json.Unmarshal([]byte(inputData), &eventSlice)
+
+	// Any implements MetaTeller so you can call its methods directly
+	// if you e.g. only need the event's ID.
+	fmt.Printf("The array contains an event with ID %s.\n", eventSlice[0].ID())
+
+	// Or use a type switch if you want access to the full event.
+	switch event := eventSlice[0].Get().(type) {
+	case *CompositionDefinedV3:
+		fmt.Printf("It's a CompositionDefined event with the name %q.\n", event.Data.Name)
+	default:
+		fmt.Println("Unsupported event type.")
+	}
+
+	// Output: The array contains an event with ID aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0.
+	// It's a CompositionDefined event with the name "My Composition".
+}
+
+//go:embed testdata/any/object_with_event_array.json
+var eventArrayObjectTestJSON []byte
+
+//go:embed testdata/any/single_event.json
+var singleEventTestJSON []byte
+
+func TestAnyUnmarshalArray(t *testing.T) {
+	input, err := os.Open("testdata/any/object_with_event_array.json")
+	require.NoError(t, err)
+	defer input.Close()
+
+	var data struct {
+		Events []*Any `json:"events"`
+	}
+	require.NoError(t, json.Unmarshal(eventArrayObjectTestJSON, &data))
+
+	assert.Equal(t, "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0", data.Events[0].ID())
+	assert.Equal(t, "EiffelCompositionDefinedEvent", data.Events[0].Type())
+	assert.Equal(t, "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1", data.Events[1].ID())
+	assert.Equal(t, "EiffelArtifactCreatedEvent", data.Events[1].Type())
+}
+
+func TestAnyUnmarshalSingleMetaTeller(t *testing.T) {
+	var event Any
+	require.NoError(t, json.Unmarshal(singleEventTestJSON, &event))
+
+	assert.Equal(t, "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0", event.ID())
+	assert.Equal(t, "EiffelCompositionDefinedEvent", event.Type())
+}
+
+func TestAnyUnmarshalSingleTypeAssertion(t *testing.T) {
+	var event Any
+	require.NoError(t, json.Unmarshal(singleEventTestJSON, &event))
+
+	v, ok := event.Get().(*CompositionDefinedV3)
+	require.True(t, ok)
+	assert.Equal(t, "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0", v.ID())
+	assert.Equal(t, "EiffelCompositionDefinedEvent", v.Type())
+}
+
+func TestAnyUnmarshalMarshalSymmetric(t *testing.T) {
+	var event Any
+	require.NoError(t, json.Unmarshal(singleEventTestJSON, &event))
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(event))
+
+	assert.JSONEq(t, string(singleEventTestJSON), buf.String())
+}

--- a/testdata/any/object_with_event_array.json
+++ b/testdata/any/object_with_event_array.json
@@ -1,0 +1,28 @@
+{
+  "events": [
+    {
+      "meta": {
+        "type": "EiffelCompositionDefinedEvent",
+        "version": "3.2.0",
+        "time": 1234567890,
+        "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
+      },
+      "data": {
+        "name": "composition1"
+      },
+      "links": []
+    },
+    {
+      "meta": {
+        "type": "EiffelArtifactCreatedEvent",
+        "version": "3.1.0",
+        "time": 1234567890,
+        "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+      },
+      "data": {
+        "identity": "pkg:generic/foo@1.2.3"
+      },
+      "links": []
+    }
+  ]
+}

--- a/testdata/any/single_event.json
+++ b/testdata/any/single_event.json
@@ -1,0 +1,12 @@
+{
+  "meta": {
+    "type": "EiffelCompositionDefinedEvent",
+    "version": "3.2.0",
+    "time": 1234567890,
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
+  },
+  "data": {
+    "name": "composition1"
+  },
+  "links": []
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #8

### Description of the Change
Introduce the struct type Any which implements json.Marshaler and json.Unmarshaler (and MetaTeller). This type can be used when you have a compound JSON data structure (a slice or a struct) that contains one or more Eiffel events and you want to unmarshal all of it in one go.

### Alternate Designs
None.

### Benefits
Much improved support for compound data structures.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
