### PR TITLE
Add routingkey package with function that generates a Sepia routing key for events

### DIFF
--- a/routingkey/sepia.go
+++ b/routingkey/sepia.go
@@ -1,0 +1,23 @@
+// Package routingkey contains functions for generating AMQP routing keys (topics) based on Eiffel events.
+package routingkey
+
+import (
+	"fmt"
+
+	"github.com/eiffel-community/eiffelevents-sdk-go"
+)
+
+// Sepia returns the AMQP routing key that the Sepia standard recommends
+// (https://eiffel-community.github.io/eiffel-sepia/rabbitmq-message-broker.html).
+// The family and tag strings are optional and may be empty. If they're empty
+// a short replacement string will be used in their place.
+func Sepia(event eiffelevents.MetaTeller, family string, tag string) string {
+	return fmt.Sprintf("eiffel.%s.%s.%s.%s", valueOrDefault(family), event.Type(), valueOrDefault(tag), valueOrDefault(event.DomainID()))
+}
+
+func valueOrDefault(value string) string {
+	if value != "" {
+		return value
+	}
+	return "_"
+}

--- a/routingkey/sepia_test.go
+++ b/routingkey/sepia_test.go
@@ -1,0 +1,64 @@
+package routingkey
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rooteiffelevents "github.com/eiffel-community/eiffelevents-sdk-go"
+	eiffelevents "github.com/eiffel-community/eiffelevents-sdk-go/editions/lyon"
+)
+
+func ExampleSepia() {
+	event, _ := eiffelevents.NewCompositionDefined()
+	fmt.Println(Sepia(event, "", "random-tag"))
+	// Output: eiffel._.EiffelCompositionDefinedEvent.random-tag._
+}
+
+func TestSepia(t *testing.T) {
+	testcases := []struct {
+		name     string
+		domainID string
+		family   string
+		tag      string
+		expected string
+	}{
+		{
+			"Minimal example with no extras",
+			"",
+			"",
+			"",
+			"eiffel._.EiffelCompositionDefinedEvent._._",
+		},
+		{
+			"With domain ID",
+			"example",
+			"",
+			"",
+			"eiffel._.EiffelCompositionDefinedEvent._.example",
+		},
+		{
+			"With family",
+			"",
+			"example",
+			"",
+			"eiffel.example.EiffelCompositionDefinedEvent._._",
+		},
+		{
+			"With tag",
+			"",
+			"",
+			"example",
+			"eiffel._.EiffelCompositionDefinedEvent.example._",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			event, err := eiffelevents.NewCompositionDefined(rooteiffelevents.WithSourceDomainID(tc.domainID))
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, Sepia(event, tc.family, tc.tag))
+		})
+	}
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #23

### Description of the Change
Everyone that publishes events to an AMQP-based Eiffel bus should use a routing key that follows the [Sepia standard](https://eiffel-community.github.io/eiffel-sepia/rabbitmq-message-broker.html). We hereby add a new package with a single simple function that does this for any given event.

### Alternate Designs
None.

### Benefits
Easier to generate a correct routing key.

### Possible Drawbacks
Technically none, but it could be argued that broker-specific things doesn't belong in an events SDK.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
