### PR TITLE
Add modifiers for meta.source.serializer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/renameio v1.0.1
 	github.com/google/uuid v1.3.0
 	github.com/lestrrat-go/jsschema v0.0.0-20181205002244-5c81c58ffcc3
+	github.com/package-url/packageurl-go v0.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.9.4
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlW
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/package-url/packageurl-go v0.1.0 h1:efWBc98O/dBZRg1pw2xiDzovnlMjCa9NPnfaiBduh8I=
+github.com/package-url/packageurl-go v0.1.0/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/modifiers_test.go
+++ b/modifiers_test.go
@@ -18,6 +18,7 @@ package eiffelevents
 
 import (
 	"fmt"
+	"runtime/debug"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,34 @@ func ExampleModifier() {
 	// Output: example.com
 }
 
+func TestPurlFromBuildInfo(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    debug.BuildInfo
+		expected string
+	}{
+		{
+			name: "Non-empty namespace",
+			input: debug.BuildInfo{
+				Path: "github.com/foo/bar",
+			},
+			expected: "pkg:golang/github.com/foo/bar",
+		},
+		{
+			name: "Empty namespace",
+			input: debug.BuildInfo{
+				Path: "main",
+			},
+			expected: "pkg:golang/main",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, purlFromBuildInfo(&tc.input).String())
+		})
+	}
+}
+
 func TestWithSourceDomainID(t *testing.T) {
 	event, err := NewCompositionDefinedV3(WithSourceDomainID("example.com"))
 	assert.NoError(t, err)
@@ -52,6 +81,12 @@ func TestWithSourceName(t *testing.T) {
 	event, err := NewCompositionDefinedV3(WithSourceName("My Application"))
 	assert.NoError(t, err)
 	assert.Equal(t, "My Application", event.Meta.Source.Name)
+}
+
+func TestWithSourceSerializer(t *testing.T) {
+	event, err := NewCompositionDefinedV3(WithSourceSerializer("pkg:golang/github.com/foo/bar"))
+	assert.NoError(t, err)
+	assert.Equal(t, "pkg:golang/github.com/foo/bar", event.Meta.Source.Serializer)
 }
 
 func TestWithSourceURI(t *testing.T) {


### PR DESCRIPTION
### Applicable Issues
Fixes #25 

### Description of the Change
This new Modifier populates meta.source.serializer with the purl of the program's main package, e.g.  pkg:golang/github.com/a/b@1.0.0. The version needs to be supplied by the caller since it doesn't appear to be trivial to figure it out automatically (even with Go 1.18's better VCS support), but that's something we can revisit later if needed.

### Alternate Designs
None.

### Benefits
This makes it easier to populate meta.source.serializer with useful data.

### Possible Drawbacks
None. The use of the modifier is optional. Well, it does add a new (small) third-party dependency for constructing purls.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
