### PR TITLE
EiffelEventLinkV1: Fix godoc typo

### DIFF
--- a/EiffelEventLinkV1.go
+++ b/EiffelEventLinkV1.go
@@ -29,7 +29,7 @@ func (links *EventLinksV1) Add(linkType string, target MetaTeller) {
 	*links = append(*links, EventLinkV1{Target: target.ID(), Type: linkType})
 }
 
-// Add adds a new link of the specified type to a target event identified by an ID.
+// AddByID adds a new link of the specified type to a target event identified by an ID.
 func (links *EventLinksV1) AddByID(linkType string, target string) {
 	*links = append(*links, EventLinkV1{Target: target, Type: linkType})
 }

--- a/internal/cmd/eventgen/templates/linkfile.tmpl
+++ b/internal/cmd/eventgen/templates/linkfile.tmpl
@@ -31,7 +31,7 @@ func (links *{{$sliceType}}) Add(linkType string, target MetaTeller) {
 	*links = append(*links, {{.StructName}}{Target: target.ID(), Type: linkType})
 }
 
-// Add adds a new link of the specified type to a target event identified by an ID.
+// AddByID adds a new link of the specified type to a target event identified by an ID.
 func (links *{{$sliceType}}) AddByID(linkType string, target string) {
 	*links = append(*links, {{.StructName}}{Target: target, Type: linkType})
 }


### PR DESCRIPTION
### Applicable Issues
N/A; trivial typo correction

### Description of the Change
A copy/paste error had the godoc comment for EventEventLinkV1.AddByID reference EventEventLinkV1.Add. This is addressed in the template and the generated file.

### Alternate Designs
None.

### Benefits
Fewer typos. None, even?

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
