### PR TITLE
Use os.ReadFile whenever possible

### DIFF
--- a/events_test.go
+++ b/events_test.go
@@ -19,13 +19,13 @@ package eiffelevents
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //go:generate go run ./internal/cmd/roundtriptestgen protocol/examples/events events_test_roundtripdata.go
@@ -37,22 +37,15 @@ import (
 func TestRoundtrip(t *testing.T) {
 	for _, tc := range eventRoundTripTestTable {
 		t.Run(tc.Filename, func(t *testing.T) {
-			f, err := os.Open(tc.Filename)
-			if err != nil {
-				t.Fatal(err.Error())
-			}
-			defer f.Close()
-			input, err := io.ReadAll(f)
-			if err != nil {
-				t.Fatal(err.Error())
-			}
+			input, err := os.ReadFile(tc.Filename)
+			require.NoError(t, err)
 
 			event, err := UnmarshalAny(input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.IsType(t, tc.ExpectedType, event)
 
 			output, err := json.Marshal(event)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.JSONEq(t, string(input), string(output))
 		})
 	}

--- a/internal/cmd/roundtriptestgen/main.go
+++ b/internal/cmd/roundtriptestgen/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	_ "embed"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -48,13 +47,7 @@ func generateExampleTable(exampleDir string, output *codetemplate.OutputFile) er
 
 	var table []tableEntry
 	for _, filename := range filenames {
-		f, err := os.Open(filename)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		eventExample, err := io.ReadAll(f)
+		eventExample, err := os.ReadFile(filename)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Applicable Issues
Fixes #68

### Description of the Change
There's no reason to open files only to call io.ReadAll() when we can use os.ReadFile() instead.

### Alternate Designs
None.

### Benefits
Less unnecessarily verbose code.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
