### PR TITLE
signature: Make AuthorIdentity implement {Marshal,Unmarshal}Text

### DIFF
--- a/signature/authoridentity.go
+++ b/signature/authoridentity.go
@@ -1,3 +1,19 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package signature
 
 import (

--- a/signature/authoridentity.go
+++ b/signature/authoridentity.go
@@ -1,0 +1,50 @@
+package signature
+
+import (
+	"fmt"
+
+	"github.com/go-ldap/ldap"
+)
+
+// AuthorIdentity is a representation of the distinguished name
+// in the meta.security.authorIdentity field of an Eiffel event.
+// It can be compared to other values of the same type.
+type AuthorIdentity struct {
+	dn       *ldap.DN
+	original string
+}
+
+func NewAuthorIdentity(s string) (*AuthorIdentity, error) {
+	dn, err := ldap.ParseDN(s)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing author identity %q: %w", s, err)
+	}
+	return &AuthorIdentity{
+		dn:       dn,
+		original: s,
+	}, nil
+}
+
+// Equal returns true if the provided *AuthorIdentity is equal to this one,
+// igoring differences in whitespace etc.
+func (ai AuthorIdentity) Equal(other *AuthorIdentity) bool {
+	return ai.dn.Equal(other.dn)
+}
+
+func (ai AuthorIdentity) String() string {
+	return ai.original
+}
+
+func (ai AuthorIdentity) MarshalText() (text []byte, err error) {
+	return []byte(ai.original), nil
+}
+
+func (ai *AuthorIdentity) UnmarshalText(text []byte) error {
+	i, err := NewAuthorIdentity(string(text))
+	if err != nil {
+		return err
+	}
+	ai.dn = i.dn
+	ai.original = i.original
+	return nil
+}

--- a/signature/authoridentity_test.go
+++ b/signature/authoridentity_test.go
@@ -1,0 +1,17 @@
+package signature
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorIdentity_UnmarshalText(t *testing.T) {
+	var data struct {
+		Identity *AuthorIdentity `json:"identity"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(`{"identity": "CN=foo,DC=example,DC=com"}`), &data))
+	assert.Equal(t, "CN=foo,DC=example,DC=com", data.Identity.String())
+}

--- a/signature/authoridentity_test.go
+++ b/signature/authoridentity_test.go
@@ -1,3 +1,19 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package signature
 
 import (

--- a/signature/verifier.go
+++ b/signature/verifier.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/go-ldap/ldap"
 	"github.com/gowebpki/jcs"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -42,35 +41,6 @@ type PublicKeyLocator interface {
 	// or an empty or nil slice if no public keys were found. An error return indicates
 	// that the lookup itself failed.
 	Locate(ctx context.Context, identity *AuthorIdentity) ([]crypto.PublicKey, error)
-}
-
-// AuthorIdentity is a representation of the distinguished name
-// in the meta.security.authorIdentity field of an Eiffel event.
-// It can be compared to other values of the same type.
-type AuthorIdentity struct {
-	dn       *ldap.DN
-	original string
-}
-
-func NewAuthorIdentity(s string) (*AuthorIdentity, error) {
-	dn, err := ldap.ParseDN(s)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing author identity %q: %w", s, err)
-	}
-	return &AuthorIdentity{
-		dn:       dn,
-		original: s,
-	}, nil
-}
-
-// Equal returns true if the provided *AuthorIdentity is equal to this one,
-// igoring differences in whitespace etc.
-func (ai *AuthorIdentity) Equal(other *AuthorIdentity) bool {
-	return ai.dn.Equal(other.dn)
-}
-
-func (ai *AuthorIdentity) String() string {
-	return ai.original
 }
 
 // Verifier can verify whether the signature of a given Eiffel event matches


### PR DESCRIPTION
### Applicable Issues
#9

### Description of the Change
This makes it easier to e.g. put AuthorIdentity values in configuration and API structs and have the values properly marshaled to/from string.

Since the type has grown we extracted it to a file of its own to keep the clutter in verifier.go down.

### Alternate Designs
We could've implemented MarshalJSON and UnmarshalJSON instead, but MarshalText and UnmarshalText apply more broadly.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
