### PR TITLE
signature: Add CapabilityTeller interface

### DIFF
--- a/EiffelActivityCanceledEventV1.go
+++ b/EiffelActivityCanceledEventV1.go
@@ -89,8 +89,11 @@ func (e *ActivityCanceledV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityCanceledV1{}
-var _ MetaTeller = &ActivityCanceledV1{}
+var (
+	_ CapabilityTeller = &ActivityCanceledV1{}
+	_ FieldSetter      = &ActivityCanceledV1{}
+	_ MetaTeller       = &ActivityCanceledV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityCanceledV1) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityCanceledV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityCanceledV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityCanceledV1) SupportsSigning() bool {
+	return false
 }
 
 type ActivityCanceledV1 struct {

--- a/EiffelActivityCanceledEventV2.go
+++ b/EiffelActivityCanceledEventV2.go
@@ -89,8 +89,11 @@ func (e *ActivityCanceledV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityCanceledV2{}
-var _ MetaTeller = &ActivityCanceledV2{}
+var (
+	_ CapabilityTeller = &ActivityCanceledV2{}
+	_ FieldSetter      = &ActivityCanceledV2{}
+	_ MetaTeller       = &ActivityCanceledV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityCanceledV2) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityCanceledV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityCanceledV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityCanceledV2) SupportsSigning() bool {
+	return false
 }
 
 type ActivityCanceledV2 struct {

--- a/EiffelActivityCanceledEventV3.go
+++ b/EiffelActivityCanceledEventV3.go
@@ -89,8 +89,11 @@ func (e *ActivityCanceledV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityCanceledV3{}
-var _ MetaTeller = &ActivityCanceledV3{}
+var (
+	_ CapabilityTeller = &ActivityCanceledV3{}
+	_ FieldSetter      = &ActivityCanceledV3{}
+	_ MetaTeller       = &ActivityCanceledV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityCanceledV3) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityCanceledV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityCanceledV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityCanceledV3) SupportsSigning() bool {
+	return true
 }
 
 type ActivityCanceledV3 struct {

--- a/EiffelActivityFinishedEventV1.go
+++ b/EiffelActivityFinishedEventV1.go
@@ -89,8 +89,11 @@ func (e *ActivityFinishedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityFinishedV1{}
-var _ MetaTeller = &ActivityFinishedV1{}
+var (
+	_ CapabilityTeller = &ActivityFinishedV1{}
+	_ FieldSetter      = &ActivityFinishedV1{}
+	_ MetaTeller       = &ActivityFinishedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityFinishedV1) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityFinishedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityFinishedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityFinishedV1) SupportsSigning() bool {
+	return false
 }
 
 type ActivityFinishedV1 struct {

--- a/EiffelActivityFinishedEventV2.go
+++ b/EiffelActivityFinishedEventV2.go
@@ -89,8 +89,11 @@ func (e *ActivityFinishedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityFinishedV2{}
-var _ MetaTeller = &ActivityFinishedV2{}
+var (
+	_ CapabilityTeller = &ActivityFinishedV2{}
+	_ FieldSetter      = &ActivityFinishedV2{}
+	_ MetaTeller       = &ActivityFinishedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityFinishedV2) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityFinishedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityFinishedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityFinishedV2) SupportsSigning() bool {
+	return false
 }
 
 type ActivityFinishedV2 struct {

--- a/EiffelActivityFinishedEventV3.go
+++ b/EiffelActivityFinishedEventV3.go
@@ -89,8 +89,11 @@ func (e *ActivityFinishedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityFinishedV3{}
-var _ MetaTeller = &ActivityFinishedV3{}
+var (
+	_ CapabilityTeller = &ActivityFinishedV3{}
+	_ FieldSetter      = &ActivityFinishedV3{}
+	_ MetaTeller       = &ActivityFinishedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityFinishedV3) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityFinishedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityFinishedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityFinishedV3) SupportsSigning() bool {
+	return true
 }
 
 type ActivityFinishedV3 struct {

--- a/EiffelActivityStartedEventV1.go
+++ b/EiffelActivityStartedEventV1.go
@@ -89,8 +89,11 @@ func (e *ActivityStartedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityStartedV1{}
-var _ MetaTeller = &ActivityStartedV1{}
+var (
+	_ CapabilityTeller = &ActivityStartedV1{}
+	_ FieldSetter      = &ActivityStartedV1{}
+	_ MetaTeller       = &ActivityStartedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityStartedV1) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityStartedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityStartedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityStartedV1) SupportsSigning() bool {
+	return false
 }
 
 type ActivityStartedV1 struct {

--- a/EiffelActivityStartedEventV2.go
+++ b/EiffelActivityStartedEventV2.go
@@ -89,8 +89,11 @@ func (e *ActivityStartedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityStartedV2{}
-var _ MetaTeller = &ActivityStartedV2{}
+var (
+	_ CapabilityTeller = &ActivityStartedV2{}
+	_ FieldSetter      = &ActivityStartedV2{}
+	_ MetaTeller       = &ActivityStartedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityStartedV2) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityStartedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityStartedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityStartedV2) SupportsSigning() bool {
+	return false
 }
 
 type ActivityStartedV2 struct {

--- a/EiffelActivityStartedEventV3.go
+++ b/EiffelActivityStartedEventV3.go
@@ -89,8 +89,11 @@ func (e *ActivityStartedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityStartedV3{}
-var _ MetaTeller = &ActivityStartedV3{}
+var (
+	_ CapabilityTeller = &ActivityStartedV3{}
+	_ FieldSetter      = &ActivityStartedV3{}
+	_ MetaTeller       = &ActivityStartedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityStartedV3) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityStartedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityStartedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityStartedV3) SupportsSigning() bool {
+	return false
 }
 
 type ActivityStartedV3 struct {

--- a/EiffelActivityStartedEventV4.go
+++ b/EiffelActivityStartedEventV4.go
@@ -89,8 +89,11 @@ func (e *ActivityStartedV4) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityStartedV4{}
-var _ MetaTeller = &ActivityStartedV4{}
+var (
+	_ CapabilityTeller = &ActivityStartedV4{}
+	_ FieldSetter      = &ActivityStartedV4{}
+	_ MetaTeller       = &ActivityStartedV4{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityStartedV4) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityStartedV4) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityStartedV4) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityStartedV4) SupportsSigning() bool {
+	return true
 }
 
 type ActivityStartedV4 struct {

--- a/EiffelActivityTriggeredEventV1.go
+++ b/EiffelActivityTriggeredEventV1.go
@@ -89,8 +89,11 @@ func (e *ActivityTriggeredV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityTriggeredV1{}
-var _ MetaTeller = &ActivityTriggeredV1{}
+var (
+	_ CapabilityTeller = &ActivityTriggeredV1{}
+	_ FieldSetter      = &ActivityTriggeredV1{}
+	_ MetaTeller       = &ActivityTriggeredV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityTriggeredV1) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityTriggeredV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityTriggeredV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityTriggeredV1) SupportsSigning() bool {
+	return false
 }
 
 type ActivityTriggeredV1 struct {

--- a/EiffelActivityTriggeredEventV2.go
+++ b/EiffelActivityTriggeredEventV2.go
@@ -89,8 +89,11 @@ func (e *ActivityTriggeredV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityTriggeredV2{}
-var _ MetaTeller = &ActivityTriggeredV2{}
+var (
+	_ CapabilityTeller = &ActivityTriggeredV2{}
+	_ FieldSetter      = &ActivityTriggeredV2{}
+	_ MetaTeller       = &ActivityTriggeredV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityTriggeredV2) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityTriggeredV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityTriggeredV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityTriggeredV2) SupportsSigning() bool {
+	return false
 }
 
 type ActivityTriggeredV2 struct {

--- a/EiffelActivityTriggeredEventV3.go
+++ b/EiffelActivityTriggeredEventV3.go
@@ -89,8 +89,11 @@ func (e *ActivityTriggeredV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityTriggeredV3{}
-var _ MetaTeller = &ActivityTriggeredV3{}
+var (
+	_ CapabilityTeller = &ActivityTriggeredV3{}
+	_ FieldSetter      = &ActivityTriggeredV3{}
+	_ MetaTeller       = &ActivityTriggeredV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityTriggeredV3) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityTriggeredV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityTriggeredV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityTriggeredV3) SupportsSigning() bool {
+	return false
 }
 
 type ActivityTriggeredV3 struct {

--- a/EiffelActivityTriggeredEventV4.go
+++ b/EiffelActivityTriggeredEventV4.go
@@ -89,8 +89,11 @@ func (e *ActivityTriggeredV4) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ActivityTriggeredV4{}
-var _ MetaTeller = &ActivityTriggeredV4{}
+var (
+	_ CapabilityTeller = &ActivityTriggeredV4{}
+	_ FieldSetter      = &ActivityTriggeredV4{}
+	_ MetaTeller       = &ActivityTriggeredV4{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ActivityTriggeredV4) ID() string {
@@ -115,6 +118,13 @@ func (e ActivityTriggeredV4) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ActivityTriggeredV4) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ActivityTriggeredV4) SupportsSigning() bool {
+	return true
 }
 
 type ActivityTriggeredV4 struct {

--- a/EiffelAnnouncementPublishedEventV1.go
+++ b/EiffelAnnouncementPublishedEventV1.go
@@ -89,8 +89,11 @@ func (e *AnnouncementPublishedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &AnnouncementPublishedV1{}
-var _ MetaTeller = &AnnouncementPublishedV1{}
+var (
+	_ CapabilityTeller = &AnnouncementPublishedV1{}
+	_ FieldSetter      = &AnnouncementPublishedV1{}
+	_ MetaTeller       = &AnnouncementPublishedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e AnnouncementPublishedV1) ID() string {
@@ -115,6 +118,13 @@ func (e AnnouncementPublishedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e AnnouncementPublishedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e AnnouncementPublishedV1) SupportsSigning() bool {
+	return false
 }
 
 type AnnouncementPublishedV1 struct {

--- a/EiffelAnnouncementPublishedEventV2.go
+++ b/EiffelAnnouncementPublishedEventV2.go
@@ -89,8 +89,11 @@ func (e *AnnouncementPublishedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &AnnouncementPublishedV2{}
-var _ MetaTeller = &AnnouncementPublishedV2{}
+var (
+	_ CapabilityTeller = &AnnouncementPublishedV2{}
+	_ FieldSetter      = &AnnouncementPublishedV2{}
+	_ MetaTeller       = &AnnouncementPublishedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e AnnouncementPublishedV2) ID() string {
@@ -115,6 +118,13 @@ func (e AnnouncementPublishedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e AnnouncementPublishedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e AnnouncementPublishedV2) SupportsSigning() bool {
+	return false
 }
 
 type AnnouncementPublishedV2 struct {

--- a/EiffelAnnouncementPublishedEventV3.go
+++ b/EiffelAnnouncementPublishedEventV3.go
@@ -89,8 +89,11 @@ func (e *AnnouncementPublishedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &AnnouncementPublishedV3{}
-var _ MetaTeller = &AnnouncementPublishedV3{}
+var (
+	_ CapabilityTeller = &AnnouncementPublishedV3{}
+	_ FieldSetter      = &AnnouncementPublishedV3{}
+	_ MetaTeller       = &AnnouncementPublishedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e AnnouncementPublishedV3) ID() string {
@@ -115,6 +118,13 @@ func (e AnnouncementPublishedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e AnnouncementPublishedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e AnnouncementPublishedV3) SupportsSigning() bool {
+	return true
 }
 
 type AnnouncementPublishedV3 struct {

--- a/EiffelArtifactCreatedEventV1.go
+++ b/EiffelArtifactCreatedEventV1.go
@@ -89,8 +89,11 @@ func (e *ArtifactCreatedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactCreatedV1{}
-var _ MetaTeller = &ArtifactCreatedV1{}
+var (
+	_ CapabilityTeller = &ArtifactCreatedV1{}
+	_ FieldSetter      = &ArtifactCreatedV1{}
+	_ MetaTeller       = &ArtifactCreatedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactCreatedV1) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactCreatedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactCreatedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactCreatedV1) SupportsSigning() bool {
+	return false
 }
 
 type ArtifactCreatedV1 struct {

--- a/EiffelArtifactCreatedEventV2.go
+++ b/EiffelArtifactCreatedEventV2.go
@@ -89,8 +89,11 @@ func (e *ArtifactCreatedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactCreatedV2{}
-var _ MetaTeller = &ArtifactCreatedV2{}
+var (
+	_ CapabilityTeller = &ArtifactCreatedV2{}
+	_ FieldSetter      = &ArtifactCreatedV2{}
+	_ MetaTeller       = &ArtifactCreatedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactCreatedV2) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactCreatedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactCreatedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactCreatedV2) SupportsSigning() bool {
+	return false
 }
 
 type ArtifactCreatedV2 struct {

--- a/EiffelArtifactCreatedEventV3.go
+++ b/EiffelArtifactCreatedEventV3.go
@@ -89,8 +89,11 @@ func (e *ArtifactCreatedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactCreatedV3{}
-var _ MetaTeller = &ArtifactCreatedV3{}
+var (
+	_ CapabilityTeller = &ArtifactCreatedV3{}
+	_ FieldSetter      = &ArtifactCreatedV3{}
+	_ MetaTeller       = &ArtifactCreatedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactCreatedV3) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactCreatedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactCreatedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactCreatedV3) SupportsSigning() bool {
+	return true
 }
 
 type ArtifactCreatedV3 struct {

--- a/EiffelArtifactDeployedEventV0_1_0.go
+++ b/EiffelArtifactDeployedEventV0_1_0.go
@@ -87,8 +87,11 @@ func (e *ArtifactDeployedV0_1_0) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactDeployedV0_1_0{}
-var _ MetaTeller = &ArtifactDeployedV0_1_0{}
+var (
+	_ CapabilityTeller = &ArtifactDeployedV0_1_0{}
+	_ FieldSetter      = &ArtifactDeployedV0_1_0{}
+	_ MetaTeller       = &ArtifactDeployedV0_1_0{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactDeployedV0_1_0) ID() string {
@@ -113,6 +116,13 @@ func (e ArtifactDeployedV0_1_0) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactDeployedV0_1_0) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactDeployedV0_1_0) SupportsSigning() bool {
+	return true
 }
 
 type ArtifactDeployedV0_1_0 struct {

--- a/EiffelArtifactPublishedEventV1.go
+++ b/EiffelArtifactPublishedEventV1.go
@@ -89,8 +89,11 @@ func (e *ArtifactPublishedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactPublishedV1{}
-var _ MetaTeller = &ArtifactPublishedV1{}
+var (
+	_ CapabilityTeller = &ArtifactPublishedV1{}
+	_ FieldSetter      = &ArtifactPublishedV1{}
+	_ MetaTeller       = &ArtifactPublishedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactPublishedV1) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactPublishedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactPublishedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactPublishedV1) SupportsSigning() bool {
+	return false
 }
 
 type ArtifactPublishedV1 struct {

--- a/EiffelArtifactPublishedEventV2.go
+++ b/EiffelArtifactPublishedEventV2.go
@@ -89,8 +89,11 @@ func (e *ArtifactPublishedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactPublishedV2{}
-var _ MetaTeller = &ArtifactPublishedV2{}
+var (
+	_ CapabilityTeller = &ArtifactPublishedV2{}
+	_ FieldSetter      = &ArtifactPublishedV2{}
+	_ MetaTeller       = &ArtifactPublishedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactPublishedV2) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactPublishedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactPublishedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactPublishedV2) SupportsSigning() bool {
+	return false
 }
 
 type ArtifactPublishedV2 struct {

--- a/EiffelArtifactPublishedEventV3.go
+++ b/EiffelArtifactPublishedEventV3.go
@@ -89,8 +89,11 @@ func (e *ArtifactPublishedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactPublishedV3{}
-var _ MetaTeller = &ArtifactPublishedV3{}
+var (
+	_ CapabilityTeller = &ArtifactPublishedV3{}
+	_ FieldSetter      = &ArtifactPublishedV3{}
+	_ MetaTeller       = &ArtifactPublishedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactPublishedV3) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactPublishedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactPublishedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactPublishedV3) SupportsSigning() bool {
+	return true
 }
 
 type ArtifactPublishedV3 struct {

--- a/EiffelArtifactReusedEventV1.go
+++ b/EiffelArtifactReusedEventV1.go
@@ -89,8 +89,11 @@ func (e *ArtifactReusedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactReusedV1{}
-var _ MetaTeller = &ArtifactReusedV1{}
+var (
+	_ CapabilityTeller = &ArtifactReusedV1{}
+	_ FieldSetter      = &ArtifactReusedV1{}
+	_ MetaTeller       = &ArtifactReusedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactReusedV1) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactReusedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactReusedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactReusedV1) SupportsSigning() bool {
+	return false
 }
 
 type ArtifactReusedV1 struct {

--- a/EiffelArtifactReusedEventV2.go
+++ b/EiffelArtifactReusedEventV2.go
@@ -89,8 +89,11 @@ func (e *ArtifactReusedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactReusedV2{}
-var _ MetaTeller = &ArtifactReusedV2{}
+var (
+	_ CapabilityTeller = &ArtifactReusedV2{}
+	_ FieldSetter      = &ArtifactReusedV2{}
+	_ MetaTeller       = &ArtifactReusedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactReusedV2) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactReusedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactReusedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactReusedV2) SupportsSigning() bool {
+	return false
 }
 
 type ArtifactReusedV2 struct {

--- a/EiffelArtifactReusedEventV3.go
+++ b/EiffelArtifactReusedEventV3.go
@@ -89,8 +89,11 @@ func (e *ArtifactReusedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ArtifactReusedV3{}
-var _ MetaTeller = &ArtifactReusedV3{}
+var (
+	_ CapabilityTeller = &ArtifactReusedV3{}
+	_ FieldSetter      = &ArtifactReusedV3{}
+	_ MetaTeller       = &ArtifactReusedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ArtifactReusedV3) ID() string {
@@ -115,6 +118,13 @@ func (e ArtifactReusedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ArtifactReusedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ArtifactReusedV3) SupportsSigning() bool {
+	return true
 }
 
 type ArtifactReusedV3 struct {

--- a/EiffelCompositionDefinedEventV1.go
+++ b/EiffelCompositionDefinedEventV1.go
@@ -89,8 +89,11 @@ func (e *CompositionDefinedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &CompositionDefinedV1{}
-var _ MetaTeller = &CompositionDefinedV1{}
+var (
+	_ CapabilityTeller = &CompositionDefinedV1{}
+	_ FieldSetter      = &CompositionDefinedV1{}
+	_ MetaTeller       = &CompositionDefinedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e CompositionDefinedV1) ID() string {
@@ -115,6 +118,13 @@ func (e CompositionDefinedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e CompositionDefinedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e CompositionDefinedV1) SupportsSigning() bool {
+	return false
 }
 
 type CompositionDefinedV1 struct {

--- a/EiffelCompositionDefinedEventV2.go
+++ b/EiffelCompositionDefinedEventV2.go
@@ -89,8 +89,11 @@ func (e *CompositionDefinedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &CompositionDefinedV2{}
-var _ MetaTeller = &CompositionDefinedV2{}
+var (
+	_ CapabilityTeller = &CompositionDefinedV2{}
+	_ FieldSetter      = &CompositionDefinedV2{}
+	_ MetaTeller       = &CompositionDefinedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e CompositionDefinedV2) ID() string {
@@ -115,6 +118,13 @@ func (e CompositionDefinedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e CompositionDefinedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e CompositionDefinedV2) SupportsSigning() bool {
+	return false
 }
 
 type CompositionDefinedV2 struct {

--- a/EiffelCompositionDefinedEventV3.go
+++ b/EiffelCompositionDefinedEventV3.go
@@ -89,8 +89,11 @@ func (e *CompositionDefinedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &CompositionDefinedV3{}
-var _ MetaTeller = &CompositionDefinedV3{}
+var (
+	_ CapabilityTeller = &CompositionDefinedV3{}
+	_ FieldSetter      = &CompositionDefinedV3{}
+	_ MetaTeller       = &CompositionDefinedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e CompositionDefinedV3) ID() string {
@@ -115,6 +118,13 @@ func (e CompositionDefinedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e CompositionDefinedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e CompositionDefinedV3) SupportsSigning() bool {
+	return true
 }
 
 type CompositionDefinedV3 struct {

--- a/EiffelConfidenceLevelModifiedEventV1.go
+++ b/EiffelConfidenceLevelModifiedEventV1.go
@@ -89,8 +89,11 @@ func (e *ConfidenceLevelModifiedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ConfidenceLevelModifiedV1{}
-var _ MetaTeller = &ConfidenceLevelModifiedV1{}
+var (
+	_ CapabilityTeller = &ConfidenceLevelModifiedV1{}
+	_ FieldSetter      = &ConfidenceLevelModifiedV1{}
+	_ MetaTeller       = &ConfidenceLevelModifiedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ConfidenceLevelModifiedV1) ID() string {
@@ -115,6 +118,13 @@ func (e ConfidenceLevelModifiedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ConfidenceLevelModifiedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ConfidenceLevelModifiedV1) SupportsSigning() bool {
+	return false
 }
 
 type ConfidenceLevelModifiedV1 struct {

--- a/EiffelConfidenceLevelModifiedEventV2.go
+++ b/EiffelConfidenceLevelModifiedEventV2.go
@@ -89,8 +89,11 @@ func (e *ConfidenceLevelModifiedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ConfidenceLevelModifiedV2{}
-var _ MetaTeller = &ConfidenceLevelModifiedV2{}
+var (
+	_ CapabilityTeller = &ConfidenceLevelModifiedV2{}
+	_ FieldSetter      = &ConfidenceLevelModifiedV2{}
+	_ MetaTeller       = &ConfidenceLevelModifiedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ConfidenceLevelModifiedV2) ID() string {
@@ -115,6 +118,13 @@ func (e ConfidenceLevelModifiedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ConfidenceLevelModifiedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ConfidenceLevelModifiedV2) SupportsSigning() bool {
+	return false
 }
 
 type ConfidenceLevelModifiedV2 struct {

--- a/EiffelConfidenceLevelModifiedEventV3.go
+++ b/EiffelConfidenceLevelModifiedEventV3.go
@@ -89,8 +89,11 @@ func (e *ConfidenceLevelModifiedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &ConfidenceLevelModifiedV3{}
-var _ MetaTeller = &ConfidenceLevelModifiedV3{}
+var (
+	_ CapabilityTeller = &ConfidenceLevelModifiedV3{}
+	_ FieldSetter      = &ConfidenceLevelModifiedV3{}
+	_ MetaTeller       = &ConfidenceLevelModifiedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e ConfidenceLevelModifiedV3) ID() string {
@@ -115,6 +118,13 @@ func (e ConfidenceLevelModifiedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e ConfidenceLevelModifiedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e ConfidenceLevelModifiedV3) SupportsSigning() bool {
+	return true
 }
 
 type ConfidenceLevelModifiedV3 struct {

--- a/EiffelEnvironmentDefinedEventV1.go
+++ b/EiffelEnvironmentDefinedEventV1.go
@@ -89,8 +89,11 @@ func (e *EnvironmentDefinedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &EnvironmentDefinedV1{}
-var _ MetaTeller = &EnvironmentDefinedV1{}
+var (
+	_ CapabilityTeller = &EnvironmentDefinedV1{}
+	_ FieldSetter      = &EnvironmentDefinedV1{}
+	_ MetaTeller       = &EnvironmentDefinedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e EnvironmentDefinedV1) ID() string {
@@ -115,6 +118,13 @@ func (e EnvironmentDefinedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e EnvironmentDefinedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e EnvironmentDefinedV1) SupportsSigning() bool {
+	return false
 }
 
 type EnvironmentDefinedV1 struct {

--- a/EiffelEnvironmentDefinedEventV2.go
+++ b/EiffelEnvironmentDefinedEventV2.go
@@ -89,8 +89,11 @@ func (e *EnvironmentDefinedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &EnvironmentDefinedV2{}
-var _ MetaTeller = &EnvironmentDefinedV2{}
+var (
+	_ CapabilityTeller = &EnvironmentDefinedV2{}
+	_ FieldSetter      = &EnvironmentDefinedV2{}
+	_ MetaTeller       = &EnvironmentDefinedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e EnvironmentDefinedV2) ID() string {
@@ -115,6 +118,13 @@ func (e EnvironmentDefinedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e EnvironmentDefinedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e EnvironmentDefinedV2) SupportsSigning() bool {
+	return false
 }
 
 type EnvironmentDefinedV2 struct {

--- a/EiffelEnvironmentDefinedEventV3.go
+++ b/EiffelEnvironmentDefinedEventV3.go
@@ -89,8 +89,11 @@ func (e *EnvironmentDefinedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &EnvironmentDefinedV3{}
-var _ MetaTeller = &EnvironmentDefinedV3{}
+var (
+	_ CapabilityTeller = &EnvironmentDefinedV3{}
+	_ FieldSetter      = &EnvironmentDefinedV3{}
+	_ MetaTeller       = &EnvironmentDefinedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e EnvironmentDefinedV3) ID() string {
@@ -115,6 +118,13 @@ func (e EnvironmentDefinedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e EnvironmentDefinedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e EnvironmentDefinedV3) SupportsSigning() bool {
+	return true
 }
 
 type EnvironmentDefinedV3 struct {

--- a/EiffelFlowContextDefinedEventV1.go
+++ b/EiffelFlowContextDefinedEventV1.go
@@ -89,8 +89,11 @@ func (e *FlowContextDefinedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &FlowContextDefinedV1{}
-var _ MetaTeller = &FlowContextDefinedV1{}
+var (
+	_ CapabilityTeller = &FlowContextDefinedV1{}
+	_ FieldSetter      = &FlowContextDefinedV1{}
+	_ MetaTeller       = &FlowContextDefinedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e FlowContextDefinedV1) ID() string {
@@ -115,6 +118,13 @@ func (e FlowContextDefinedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e FlowContextDefinedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e FlowContextDefinedV1) SupportsSigning() bool {
+	return false
 }
 
 type FlowContextDefinedV1 struct {

--- a/EiffelFlowContextDefinedEventV2.go
+++ b/EiffelFlowContextDefinedEventV2.go
@@ -89,8 +89,11 @@ func (e *FlowContextDefinedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &FlowContextDefinedV2{}
-var _ MetaTeller = &FlowContextDefinedV2{}
+var (
+	_ CapabilityTeller = &FlowContextDefinedV2{}
+	_ FieldSetter      = &FlowContextDefinedV2{}
+	_ MetaTeller       = &FlowContextDefinedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e FlowContextDefinedV2) ID() string {
@@ -115,6 +118,13 @@ func (e FlowContextDefinedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e FlowContextDefinedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e FlowContextDefinedV2) SupportsSigning() bool {
+	return false
 }
 
 type FlowContextDefinedV2 struct {

--- a/EiffelFlowContextDefinedEventV3.go
+++ b/EiffelFlowContextDefinedEventV3.go
@@ -89,8 +89,11 @@ func (e *FlowContextDefinedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &FlowContextDefinedV3{}
-var _ MetaTeller = &FlowContextDefinedV3{}
+var (
+	_ CapabilityTeller = &FlowContextDefinedV3{}
+	_ FieldSetter      = &FlowContextDefinedV3{}
+	_ MetaTeller       = &FlowContextDefinedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e FlowContextDefinedV3) ID() string {
@@ -115,6 +118,13 @@ func (e FlowContextDefinedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e FlowContextDefinedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e FlowContextDefinedV3) SupportsSigning() bool {
+	return true
 }
 
 type FlowContextDefinedV3 struct {

--- a/EiffelIssueDefinedEventV1.go
+++ b/EiffelIssueDefinedEventV1.go
@@ -89,8 +89,11 @@ func (e *IssueDefinedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueDefinedV1{}
-var _ MetaTeller = &IssueDefinedV1{}
+var (
+	_ CapabilityTeller = &IssueDefinedV1{}
+	_ FieldSetter      = &IssueDefinedV1{}
+	_ MetaTeller       = &IssueDefinedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueDefinedV1) ID() string {
@@ -115,6 +118,13 @@ func (e IssueDefinedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueDefinedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueDefinedV1) SupportsSigning() bool {
+	return false
 }
 
 type IssueDefinedV1 struct {

--- a/EiffelIssueDefinedEventV2.go
+++ b/EiffelIssueDefinedEventV2.go
@@ -89,8 +89,11 @@ func (e *IssueDefinedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueDefinedV2{}
-var _ MetaTeller = &IssueDefinedV2{}
+var (
+	_ CapabilityTeller = &IssueDefinedV2{}
+	_ FieldSetter      = &IssueDefinedV2{}
+	_ MetaTeller       = &IssueDefinedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueDefinedV2) ID() string {
@@ -115,6 +118,13 @@ func (e IssueDefinedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueDefinedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueDefinedV2) SupportsSigning() bool {
+	return false
 }
 
 type IssueDefinedV2 struct {

--- a/EiffelIssueDefinedEventV3.go
+++ b/EiffelIssueDefinedEventV3.go
@@ -89,8 +89,11 @@ func (e *IssueDefinedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueDefinedV3{}
-var _ MetaTeller = &IssueDefinedV3{}
+var (
+	_ CapabilityTeller = &IssueDefinedV3{}
+	_ FieldSetter      = &IssueDefinedV3{}
+	_ MetaTeller       = &IssueDefinedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueDefinedV3) ID() string {
@@ -115,6 +118,13 @@ func (e IssueDefinedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueDefinedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueDefinedV3) SupportsSigning() bool {
+	return true
 }
 
 type IssueDefinedV3 struct {

--- a/EiffelIssueVerifiedEventV1.go
+++ b/EiffelIssueVerifiedEventV1.go
@@ -89,8 +89,11 @@ func (e *IssueVerifiedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueVerifiedV1{}
-var _ MetaTeller = &IssueVerifiedV1{}
+var (
+	_ CapabilityTeller = &IssueVerifiedV1{}
+	_ FieldSetter      = &IssueVerifiedV1{}
+	_ MetaTeller       = &IssueVerifiedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueVerifiedV1) ID() string {
@@ -115,6 +118,13 @@ func (e IssueVerifiedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueVerifiedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueVerifiedV1) SupportsSigning() bool {
+	return false
 }
 
 type IssueVerifiedV1 struct {

--- a/EiffelIssueVerifiedEventV2.go
+++ b/EiffelIssueVerifiedEventV2.go
@@ -89,8 +89,11 @@ func (e *IssueVerifiedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueVerifiedV2{}
-var _ MetaTeller = &IssueVerifiedV2{}
+var (
+	_ CapabilityTeller = &IssueVerifiedV2{}
+	_ FieldSetter      = &IssueVerifiedV2{}
+	_ MetaTeller       = &IssueVerifiedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueVerifiedV2) ID() string {
@@ -115,6 +118,13 @@ func (e IssueVerifiedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueVerifiedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueVerifiedV2) SupportsSigning() bool {
+	return false
 }
 
 type IssueVerifiedV2 struct {

--- a/EiffelIssueVerifiedEventV3.go
+++ b/EiffelIssueVerifiedEventV3.go
@@ -89,8 +89,11 @@ func (e *IssueVerifiedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueVerifiedV3{}
-var _ MetaTeller = &IssueVerifiedV3{}
+var (
+	_ CapabilityTeller = &IssueVerifiedV3{}
+	_ FieldSetter      = &IssueVerifiedV3{}
+	_ MetaTeller       = &IssueVerifiedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueVerifiedV3) ID() string {
@@ -115,6 +118,13 @@ func (e IssueVerifiedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueVerifiedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueVerifiedV3) SupportsSigning() bool {
+	return false
 }
 
 type IssueVerifiedV3 struct {

--- a/EiffelIssueVerifiedEventV4.go
+++ b/EiffelIssueVerifiedEventV4.go
@@ -89,8 +89,11 @@ func (e *IssueVerifiedV4) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &IssueVerifiedV4{}
-var _ MetaTeller = &IssueVerifiedV4{}
+var (
+	_ CapabilityTeller = &IssueVerifiedV4{}
+	_ FieldSetter      = &IssueVerifiedV4{}
+	_ MetaTeller       = &IssueVerifiedV4{}
+)
 
 // ID returns the value of the meta.id field.
 func (e IssueVerifiedV4) ID() string {
@@ -115,6 +118,13 @@ func (e IssueVerifiedV4) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e IssueVerifiedV4) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e IssueVerifiedV4) SupportsSigning() bool {
+	return true
 }
 
 type IssueVerifiedV4 struct {

--- a/EiffelSourceChangeCreatedEventV1.go
+++ b/EiffelSourceChangeCreatedEventV1.go
@@ -89,8 +89,11 @@ func (e *SourceChangeCreatedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeCreatedV1{}
-var _ MetaTeller = &SourceChangeCreatedV1{}
+var (
+	_ CapabilityTeller = &SourceChangeCreatedV1{}
+	_ FieldSetter      = &SourceChangeCreatedV1{}
+	_ MetaTeller       = &SourceChangeCreatedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeCreatedV1) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeCreatedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeCreatedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeCreatedV1) SupportsSigning() bool {
+	return false
 }
 
 type SourceChangeCreatedV1 struct {

--- a/EiffelSourceChangeCreatedEventV2.go
+++ b/EiffelSourceChangeCreatedEventV2.go
@@ -89,8 +89,11 @@ func (e *SourceChangeCreatedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeCreatedV2{}
-var _ MetaTeller = &SourceChangeCreatedV2{}
+var (
+	_ CapabilityTeller = &SourceChangeCreatedV2{}
+	_ FieldSetter      = &SourceChangeCreatedV2{}
+	_ MetaTeller       = &SourceChangeCreatedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeCreatedV2) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeCreatedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeCreatedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeCreatedV2) SupportsSigning() bool {
+	return false
 }
 
 type SourceChangeCreatedV2 struct {

--- a/EiffelSourceChangeCreatedEventV3.go
+++ b/EiffelSourceChangeCreatedEventV3.go
@@ -89,8 +89,11 @@ func (e *SourceChangeCreatedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeCreatedV3{}
-var _ MetaTeller = &SourceChangeCreatedV3{}
+var (
+	_ CapabilityTeller = &SourceChangeCreatedV3{}
+	_ FieldSetter      = &SourceChangeCreatedV3{}
+	_ MetaTeller       = &SourceChangeCreatedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeCreatedV3) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeCreatedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeCreatedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeCreatedV3) SupportsSigning() bool {
+	return false
 }
 
 type SourceChangeCreatedV3 struct {

--- a/EiffelSourceChangeCreatedEventV4.go
+++ b/EiffelSourceChangeCreatedEventV4.go
@@ -89,8 +89,11 @@ func (e *SourceChangeCreatedV4) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeCreatedV4{}
-var _ MetaTeller = &SourceChangeCreatedV4{}
+var (
+	_ CapabilityTeller = &SourceChangeCreatedV4{}
+	_ FieldSetter      = &SourceChangeCreatedV4{}
+	_ MetaTeller       = &SourceChangeCreatedV4{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeCreatedV4) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeCreatedV4) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeCreatedV4) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeCreatedV4) SupportsSigning() bool {
+	return true
 }
 
 type SourceChangeCreatedV4 struct {

--- a/EiffelSourceChangeSubmittedEventV1.go
+++ b/EiffelSourceChangeSubmittedEventV1.go
@@ -89,8 +89,11 @@ func (e *SourceChangeSubmittedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeSubmittedV1{}
-var _ MetaTeller = &SourceChangeSubmittedV1{}
+var (
+	_ CapabilityTeller = &SourceChangeSubmittedV1{}
+	_ FieldSetter      = &SourceChangeSubmittedV1{}
+	_ MetaTeller       = &SourceChangeSubmittedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeSubmittedV1) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeSubmittedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeSubmittedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeSubmittedV1) SupportsSigning() bool {
+	return false
 }
 
 type SourceChangeSubmittedV1 struct {

--- a/EiffelSourceChangeSubmittedEventV2.go
+++ b/EiffelSourceChangeSubmittedEventV2.go
@@ -89,8 +89,11 @@ func (e *SourceChangeSubmittedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeSubmittedV2{}
-var _ MetaTeller = &SourceChangeSubmittedV2{}
+var (
+	_ CapabilityTeller = &SourceChangeSubmittedV2{}
+	_ FieldSetter      = &SourceChangeSubmittedV2{}
+	_ MetaTeller       = &SourceChangeSubmittedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeSubmittedV2) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeSubmittedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeSubmittedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeSubmittedV2) SupportsSigning() bool {
+	return false
 }
 
 type SourceChangeSubmittedV2 struct {

--- a/EiffelSourceChangeSubmittedEventV3.go
+++ b/EiffelSourceChangeSubmittedEventV3.go
@@ -89,8 +89,11 @@ func (e *SourceChangeSubmittedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &SourceChangeSubmittedV3{}
-var _ MetaTeller = &SourceChangeSubmittedV3{}
+var (
+	_ CapabilityTeller = &SourceChangeSubmittedV3{}
+	_ FieldSetter      = &SourceChangeSubmittedV3{}
+	_ MetaTeller       = &SourceChangeSubmittedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e SourceChangeSubmittedV3) ID() string {
@@ -115,6 +118,13 @@ func (e SourceChangeSubmittedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e SourceChangeSubmittedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e SourceChangeSubmittedV3) SupportsSigning() bool {
+	return true
 }
 
 type SourceChangeSubmittedV3 struct {

--- a/EiffelTestCaseCanceledEventV1.go
+++ b/EiffelTestCaseCanceledEventV1.go
@@ -89,8 +89,11 @@ func (e *TestCaseCanceledV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseCanceledV1{}
-var _ MetaTeller = &TestCaseCanceledV1{}
+var (
+	_ CapabilityTeller = &TestCaseCanceledV1{}
+	_ FieldSetter      = &TestCaseCanceledV1{}
+	_ MetaTeller       = &TestCaseCanceledV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseCanceledV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseCanceledV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseCanceledV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseCanceledV1) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseCanceledV1 struct {

--- a/EiffelTestCaseCanceledEventV2.go
+++ b/EiffelTestCaseCanceledEventV2.go
@@ -89,8 +89,11 @@ func (e *TestCaseCanceledV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseCanceledV2{}
-var _ MetaTeller = &TestCaseCanceledV2{}
+var (
+	_ CapabilityTeller = &TestCaseCanceledV2{}
+	_ FieldSetter      = &TestCaseCanceledV2{}
+	_ MetaTeller       = &TestCaseCanceledV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseCanceledV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseCanceledV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseCanceledV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseCanceledV2) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseCanceledV2 struct {

--- a/EiffelTestCaseCanceledEventV3.go
+++ b/EiffelTestCaseCanceledEventV3.go
@@ -89,8 +89,11 @@ func (e *TestCaseCanceledV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseCanceledV3{}
-var _ MetaTeller = &TestCaseCanceledV3{}
+var (
+	_ CapabilityTeller = &TestCaseCanceledV3{}
+	_ FieldSetter      = &TestCaseCanceledV3{}
+	_ MetaTeller       = &TestCaseCanceledV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseCanceledV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseCanceledV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseCanceledV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseCanceledV3) SupportsSigning() bool {
+	return true
 }
 
 type TestCaseCanceledV3 struct {

--- a/EiffelTestCaseFinishedEventV1.go
+++ b/EiffelTestCaseFinishedEventV1.go
@@ -89,8 +89,11 @@ func (e *TestCaseFinishedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseFinishedV1{}
-var _ MetaTeller = &TestCaseFinishedV1{}
+var (
+	_ CapabilityTeller = &TestCaseFinishedV1{}
+	_ FieldSetter      = &TestCaseFinishedV1{}
+	_ MetaTeller       = &TestCaseFinishedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseFinishedV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseFinishedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseFinishedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseFinishedV1) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseFinishedV1 struct {

--- a/EiffelTestCaseFinishedEventV2.go
+++ b/EiffelTestCaseFinishedEventV2.go
@@ -89,8 +89,11 @@ func (e *TestCaseFinishedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseFinishedV2{}
-var _ MetaTeller = &TestCaseFinishedV2{}
+var (
+	_ CapabilityTeller = &TestCaseFinishedV2{}
+	_ FieldSetter      = &TestCaseFinishedV2{}
+	_ MetaTeller       = &TestCaseFinishedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseFinishedV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseFinishedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseFinishedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseFinishedV2) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseFinishedV2 struct {

--- a/EiffelTestCaseFinishedEventV3.go
+++ b/EiffelTestCaseFinishedEventV3.go
@@ -89,8 +89,11 @@ func (e *TestCaseFinishedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseFinishedV3{}
-var _ MetaTeller = &TestCaseFinishedV3{}
+var (
+	_ CapabilityTeller = &TestCaseFinishedV3{}
+	_ FieldSetter      = &TestCaseFinishedV3{}
+	_ MetaTeller       = &TestCaseFinishedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseFinishedV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseFinishedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseFinishedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseFinishedV3) SupportsSigning() bool {
+	return true
 }
 
 type TestCaseFinishedV3 struct {

--- a/EiffelTestCaseStartedEventV1.go
+++ b/EiffelTestCaseStartedEventV1.go
@@ -89,8 +89,11 @@ func (e *TestCaseStartedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseStartedV1{}
-var _ MetaTeller = &TestCaseStartedV1{}
+var (
+	_ CapabilityTeller = &TestCaseStartedV1{}
+	_ FieldSetter      = &TestCaseStartedV1{}
+	_ MetaTeller       = &TestCaseStartedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseStartedV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseStartedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseStartedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseStartedV1) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseStartedV1 struct {

--- a/EiffelTestCaseStartedEventV2.go
+++ b/EiffelTestCaseStartedEventV2.go
@@ -89,8 +89,11 @@ func (e *TestCaseStartedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseStartedV2{}
-var _ MetaTeller = &TestCaseStartedV2{}
+var (
+	_ CapabilityTeller = &TestCaseStartedV2{}
+	_ FieldSetter      = &TestCaseStartedV2{}
+	_ MetaTeller       = &TestCaseStartedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseStartedV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseStartedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseStartedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseStartedV2) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseStartedV2 struct {

--- a/EiffelTestCaseStartedEventV3.go
+++ b/EiffelTestCaseStartedEventV3.go
@@ -89,8 +89,11 @@ func (e *TestCaseStartedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseStartedV3{}
-var _ MetaTeller = &TestCaseStartedV3{}
+var (
+	_ CapabilityTeller = &TestCaseStartedV3{}
+	_ FieldSetter      = &TestCaseStartedV3{}
+	_ MetaTeller       = &TestCaseStartedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseStartedV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseStartedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseStartedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseStartedV3) SupportsSigning() bool {
+	return true
 }
 
 type TestCaseStartedV3 struct {

--- a/EiffelTestCaseTriggeredEventV1.go
+++ b/EiffelTestCaseTriggeredEventV1.go
@@ -89,8 +89,11 @@ func (e *TestCaseTriggeredV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseTriggeredV1{}
-var _ MetaTeller = &TestCaseTriggeredV1{}
+var (
+	_ CapabilityTeller = &TestCaseTriggeredV1{}
+	_ FieldSetter      = &TestCaseTriggeredV1{}
+	_ MetaTeller       = &TestCaseTriggeredV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseTriggeredV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseTriggeredV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseTriggeredV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseTriggeredV1) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseTriggeredV1 struct {

--- a/EiffelTestCaseTriggeredEventV2.go
+++ b/EiffelTestCaseTriggeredEventV2.go
@@ -89,8 +89,11 @@ func (e *TestCaseTriggeredV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseTriggeredV2{}
-var _ MetaTeller = &TestCaseTriggeredV2{}
+var (
+	_ CapabilityTeller = &TestCaseTriggeredV2{}
+	_ FieldSetter      = &TestCaseTriggeredV2{}
+	_ MetaTeller       = &TestCaseTriggeredV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseTriggeredV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseTriggeredV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseTriggeredV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseTriggeredV2) SupportsSigning() bool {
+	return false
 }
 
 type TestCaseTriggeredV2 struct {

--- a/EiffelTestCaseTriggeredEventV3.go
+++ b/EiffelTestCaseTriggeredEventV3.go
@@ -89,8 +89,11 @@ func (e *TestCaseTriggeredV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestCaseTriggeredV3{}
-var _ MetaTeller = &TestCaseTriggeredV3{}
+var (
+	_ CapabilityTeller = &TestCaseTriggeredV3{}
+	_ FieldSetter      = &TestCaseTriggeredV3{}
+	_ MetaTeller       = &TestCaseTriggeredV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestCaseTriggeredV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestCaseTriggeredV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestCaseTriggeredV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestCaseTriggeredV3) SupportsSigning() bool {
+	return true
 }
 
 type TestCaseTriggeredV3 struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV1.go
@@ -89,8 +89,11 @@ func (e *TestExecutionRecipeCollectionCreatedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV1{}
-var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV1{}
+var (
+	_ CapabilityTeller = &TestExecutionRecipeCollectionCreatedV1{}
+	_ FieldSetter      = &TestExecutionRecipeCollectionCreatedV1{}
+	_ MetaTeller       = &TestExecutionRecipeCollectionCreatedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestExecutionRecipeCollectionCreatedV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestExecutionRecipeCollectionCreatedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestExecutionRecipeCollectionCreatedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestExecutionRecipeCollectionCreatedV1) SupportsSigning() bool {
+	return false
 }
 
 type TestExecutionRecipeCollectionCreatedV1 struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV2.go
@@ -89,8 +89,11 @@ func (e *TestExecutionRecipeCollectionCreatedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV2{}
-var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV2{}
+var (
+	_ CapabilityTeller = &TestExecutionRecipeCollectionCreatedV2{}
+	_ FieldSetter      = &TestExecutionRecipeCollectionCreatedV2{}
+	_ MetaTeller       = &TestExecutionRecipeCollectionCreatedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestExecutionRecipeCollectionCreatedV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestExecutionRecipeCollectionCreatedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestExecutionRecipeCollectionCreatedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestExecutionRecipeCollectionCreatedV2) SupportsSigning() bool {
+	return false
 }
 
 type TestExecutionRecipeCollectionCreatedV2 struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV3.go
@@ -89,8 +89,11 @@ func (e *TestExecutionRecipeCollectionCreatedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV3{}
-var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV3{}
+var (
+	_ CapabilityTeller = &TestExecutionRecipeCollectionCreatedV3{}
+	_ FieldSetter      = &TestExecutionRecipeCollectionCreatedV3{}
+	_ MetaTeller       = &TestExecutionRecipeCollectionCreatedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestExecutionRecipeCollectionCreatedV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestExecutionRecipeCollectionCreatedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestExecutionRecipeCollectionCreatedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestExecutionRecipeCollectionCreatedV3) SupportsSigning() bool {
+	return false
 }
 
 type TestExecutionRecipeCollectionCreatedV3 struct {

--- a/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
+++ b/EiffelTestExecutionRecipeCollectionCreatedEventV4.go
@@ -89,8 +89,11 @@ func (e *TestExecutionRecipeCollectionCreatedV4) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestExecutionRecipeCollectionCreatedV4{}
-var _ MetaTeller = &TestExecutionRecipeCollectionCreatedV4{}
+var (
+	_ CapabilityTeller = &TestExecutionRecipeCollectionCreatedV4{}
+	_ FieldSetter      = &TestExecutionRecipeCollectionCreatedV4{}
+	_ MetaTeller       = &TestExecutionRecipeCollectionCreatedV4{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestExecutionRecipeCollectionCreatedV4) ID() string {
@@ -115,6 +118,13 @@ func (e TestExecutionRecipeCollectionCreatedV4) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestExecutionRecipeCollectionCreatedV4) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestExecutionRecipeCollectionCreatedV4) SupportsSigning() bool {
+	return true
 }
 
 type TestExecutionRecipeCollectionCreatedV4 struct {

--- a/EiffelTestSuiteFinishedEventV1.go
+++ b/EiffelTestSuiteFinishedEventV1.go
@@ -89,8 +89,11 @@ func (e *TestSuiteFinishedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestSuiteFinishedV1{}
-var _ MetaTeller = &TestSuiteFinishedV1{}
+var (
+	_ CapabilityTeller = &TestSuiteFinishedV1{}
+	_ FieldSetter      = &TestSuiteFinishedV1{}
+	_ MetaTeller       = &TestSuiteFinishedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestSuiteFinishedV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestSuiteFinishedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestSuiteFinishedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestSuiteFinishedV1) SupportsSigning() bool {
+	return false
 }
 
 type TestSuiteFinishedV1 struct {

--- a/EiffelTestSuiteFinishedEventV2.go
+++ b/EiffelTestSuiteFinishedEventV2.go
@@ -89,8 +89,11 @@ func (e *TestSuiteFinishedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestSuiteFinishedV2{}
-var _ MetaTeller = &TestSuiteFinishedV2{}
+var (
+	_ CapabilityTeller = &TestSuiteFinishedV2{}
+	_ FieldSetter      = &TestSuiteFinishedV2{}
+	_ MetaTeller       = &TestSuiteFinishedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestSuiteFinishedV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestSuiteFinishedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestSuiteFinishedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestSuiteFinishedV2) SupportsSigning() bool {
+	return false
 }
 
 type TestSuiteFinishedV2 struct {

--- a/EiffelTestSuiteFinishedEventV3.go
+++ b/EiffelTestSuiteFinishedEventV3.go
@@ -89,8 +89,11 @@ func (e *TestSuiteFinishedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestSuiteFinishedV3{}
-var _ MetaTeller = &TestSuiteFinishedV3{}
+var (
+	_ CapabilityTeller = &TestSuiteFinishedV3{}
+	_ FieldSetter      = &TestSuiteFinishedV3{}
+	_ MetaTeller       = &TestSuiteFinishedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestSuiteFinishedV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestSuiteFinishedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestSuiteFinishedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestSuiteFinishedV3) SupportsSigning() bool {
+	return true
 }
 
 type TestSuiteFinishedV3 struct {

--- a/EiffelTestSuiteStartedEventV1.go
+++ b/EiffelTestSuiteStartedEventV1.go
@@ -89,8 +89,11 @@ func (e *TestSuiteStartedV1) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestSuiteStartedV1{}
-var _ MetaTeller = &TestSuiteStartedV1{}
+var (
+	_ CapabilityTeller = &TestSuiteStartedV1{}
+	_ FieldSetter      = &TestSuiteStartedV1{}
+	_ MetaTeller       = &TestSuiteStartedV1{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestSuiteStartedV1) ID() string {
@@ -115,6 +118,13 @@ func (e TestSuiteStartedV1) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestSuiteStartedV1) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestSuiteStartedV1) SupportsSigning() bool {
+	return false
 }
 
 type TestSuiteStartedV1 struct {

--- a/EiffelTestSuiteStartedEventV2.go
+++ b/EiffelTestSuiteStartedEventV2.go
@@ -89,8 +89,11 @@ func (e *TestSuiteStartedV2) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestSuiteStartedV2{}
-var _ MetaTeller = &TestSuiteStartedV2{}
+var (
+	_ CapabilityTeller = &TestSuiteStartedV2{}
+	_ FieldSetter      = &TestSuiteStartedV2{}
+	_ MetaTeller       = &TestSuiteStartedV2{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestSuiteStartedV2) ID() string {
@@ -115,6 +118,13 @@ func (e TestSuiteStartedV2) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestSuiteStartedV2) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestSuiteStartedV2) SupportsSigning() bool {
+	return false
 }
 
 type TestSuiteStartedV2 struct {

--- a/EiffelTestSuiteStartedEventV3.go
+++ b/EiffelTestSuiteStartedEventV3.go
@@ -89,8 +89,11 @@ func (e *TestSuiteStartedV3) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &TestSuiteStartedV3{}
-var _ MetaTeller = &TestSuiteStartedV3{}
+var (
+	_ CapabilityTeller = &TestSuiteStartedV3{}
+	_ FieldSetter      = &TestSuiteStartedV3{}
+	_ MetaTeller       = &TestSuiteStartedV3{}
+)
 
 // ID returns the value of the meta.id field.
 func (e TestSuiteStartedV3) ID() string {
@@ -115,6 +118,13 @@ func (e TestSuiteStartedV3) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e TestSuiteStartedV3) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e TestSuiteStartedV3) SupportsSigning() bool {
+	return true
 }
 
 type TestSuiteStartedV3 struct {

--- a/capabilityteller.go
+++ b/capabilityteller.go
@@ -1,0 +1,27 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eiffelevents
+
+// CapabilityTeller answers questions about the capabilities of anything that
+// resembles an Eiffel event without having to manually track which version of
+// which event type introduced this capability.
+type CapabilityTeller interface {
+	// SupportsSigning returns true if the event supports signatures according
+	// to V3 of the meta field, i.e. events where the signature is found under
+	// meta.security.integrityProtection.
+	SupportsSigning() bool
+}

--- a/internal/cmd/eventgen/templates/eventfile.tmpl
+++ b/internal/cmd/eventgen/templates/eventfile.tmpl
@@ -95,8 +95,11 @@ func (e *{{.StructName}}) String() string {
 	return string(b)
 }
 
-var _ FieldSetter = &{{.StructName}}{}
-var _ MetaTeller = &{{.StructName}}{}
+var (
+	_ CapabilityTeller = &{{.StructName}}{}
+	_ FieldSetter = &{{.StructName}}{}
+	_ MetaTeller = &{{.StructName}}{}
+)
 
 // ID returns the value of the meta.id field.
 func (e {{.StructName}}) ID() string {
@@ -121,4 +124,11 @@ func (e {{.StructName}}) Time() int64 {
 // DomainID returns the value of the meta.source.domainId field.
 func (e {{.StructName}}) DomainID() string {
 	return e.Meta.Source.DomainID
+}
+
+// SupportsSigning returns true if the event supports signatures according
+// to V3 of the meta field, i.e. events where the signature is found under
+// meta.security.integrityProtection.
+func (e {{.StructName}}) SupportsSigning() bool {
+	return {{.SupportsSigning}}
 }

--- a/signature/errors.go
+++ b/signature/errors.go
@@ -25,6 +25,7 @@ var (
 	ErrPublicKeyNotFound    = errors.New("no public key for verifying events signed by this identify was found")
 	ErrSignatureMismatch    = errors.New("the signature couldn't be verified")
 	ErrSigningFailed        = errors.New("signing of the event failed")
+	ErrSigningUnavailable   = errors.New("signing of this event type and version isn't supported")
 	ErrUnsupportedAlgorithm = errors.New("unsupported algorithm")
 	ErrUnverifiableEvent    = errors.New("event cannot be verified because an essential field is unset or empty")
 	ErrVerificationFailed   = errors.New("the signature couldn't be verified by any of the available public keys")

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,69 +54,76 @@ func TestSigner(t *testing.T) {
 		name          string
 		alg           Algorithm
 		key           crypto.Signer
-		eventFactory  func() (json.Marshaler, error)
+		eventFactory  func() (SigningSubject, error)
 		expectedError error
 	}{
 		{
 			name:         "Happy path with RS256",
 			alg:          RS256,
 			key:          rsaKey,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with RS384",
 			alg:          RS384,
 			key:          rsaKey,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with RS512",
 			alg:          RS512,
 			key:          rsaKey,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with ES256",
 			alg:          ES256,
 			key:          ecdsa256Key,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with ES384",
 			alg:          ES384,
 			key:          ecdsa384Key,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with ES512",
 			alg:          ES512,
 			key:          ecdsa521Key,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with PS256",
 			alg:          PS256,
 			key:          rsaKey,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with PS384",
 			alg:          PS384,
 			key:          rsaKey,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:         "Happy path with PS512",
 			alg:          PS512,
 			key:          rsaKey,
-			eventFactory: func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory: func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 		},
 		{
 			name:          "Algorithm and key mismatch",
 			alg:           RS256,
 			key:           ecdsa256Key,
-			eventFactory:  func() (json.Marshaler, error) { return rooteiffelevents.NewCompositionDefinedV3() },
+			eventFactory:  func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV3() },
 			expectedError: ErrSigningFailed,
+		},
+		{
+			name:          "Event is too old to support signing",
+			alg:           PS512,
+			key:           rsaKey,
+			eventFactory:  func() (SigningSubject, error) { return rooteiffelevents.NewCompositionDefinedV2() },
+			expectedError: ErrSigningUnavailable,
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
### Applicable Issues
#9

### Description of the Change
This new interface, currently with a single method that indicates whether the event can be signed, is used to return an error if the event given to Signer.Sign is too old to support signing. All events implement the CapabilityTeller interface. In the future we might want to add additional methods for expressing other capabilities of events, e.g. if they support meta.source.domainId.

### Alternate Designs
N/A

### Possible Drawbacks
None that I can think of. We impose slightly higher requirements of what's passed to Signer.Sign (no longer just json.Marshaler but also eiffelevents.MetaTeller and eiffelevents.CapabilityTeller) but I don't think that's significant.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
