### PR TITLE
signature: Expose errors returned by PublicKeyLocator

### DIFF
--- a/signature/verifier.go
+++ b/signature/verifier.go
@@ -171,10 +171,10 @@ func (v *Verifier) Verify(ctx context.Context, event []byte) error {
 
 	keys, err := v.keyLocator.Locate(ctx, dn)
 	if err != nil {
-		return fmt.Errorf("%w: %s", ErrPublicKeyLookup, identity)
+		return errors.Join(fmt.Errorf("%w: %s", ErrPublicKeyLookup, identity), err)
 	}
 	if len(keys) == 0 {
-		return fmt.Errorf("%w: %s", ErrPublicKeyNotFound, identity)
+		return errors.Join(fmt.Errorf("%w: %s", ErrPublicKeyNotFound, identity), err)
 	}
 
 	// Collect the error for each public key we try, and start with


### PR DESCRIPTION

### Applicable Issues
Fixes #103 

### Description of the Change
When the signature.PublicKeyLocator.Locate call in signature.Verifier.Verify fails to load a public key, the error returned by Locate is just thrown away, leaving the Verify caller with a generic error message. Use errors.Join like in the rest of the method.

### Alternate Designs
None

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
