### PR TITLE
Add cmd/eiffelsignature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /.vscode
 /bin
+/eiffelsignature
 /eventgen
 /roundtriptestgen

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ export PATH := $(GOBIN):$(PATH)
 .PHONY: all
 all: gen
 	$(GOBUILD) .
+	$(GOBUILD) ./cmd/eiffelsignature
 
 .PHONY: gen
 gen:

--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ The SDK supports cryptographic signing of (typically) outbound events as
 well as verification of the signature of inbound events. The signing is
 done according to the standard method, with the signature and metadata under
 the `meta.security` field. See the documentation of the signature subpackage
-for details and code examples.
+for details and code examples, but also the cmd/eiffelsignature
+subpackage from which you can build a standalone CLI executable for
+signing events and verifying such signatures.
 
 ## Code of Conduct and Contributing
 To get involved, please see [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/eiffel-community/.github/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ done according to the standard method, with the signature and metadata under
 the `meta.security` field. See the documentation of the signature subpackage
 for details and code examples, but also the cmd/eiffelsignature
 subpackage from which you can build a standalone CLI executable for
-signing events and verifying such signatures.
+signing events and verifying the signatures of signed events.
 
 ## Code of Conduct and Contributing
 To get involved, please see [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/eiffel-community/.github/blob/master/CONTRIBUTING.md).

--- a/cmd/eiffelsignature/README.md
+++ b/cmd/eiffelsignature/README.md
@@ -6,7 +6,7 @@ more events read from stdin, and `verify` that verifies one or more
 events read from stdin.
 
 Both assume that keys in PEM format, and `verify` supports reading any
-number of public keys from a director of .pem files, trying the keys for
+number of public keys from a directory of .pem files, trying the keys for
 the author identity found in the signed event until it finds one that can
 successfully verify the signature.
 

--- a/cmd/eiffelsignature/README.md
+++ b/cmd/eiffelsignature/README.md
@@ -1,0 +1,51 @@
+# eiffelsignature
+
+This package contains a CLI executable that exposes the signing features
+of the SDK. The executable has two subcommands; `sign` that signs one or
+more events read from stdin, and `verify` that verifies one or more
+events read from stdin.
+
+Both assume that keys in PEM format, and `verify` supports reading any
+number of public keys from a director of .pem files, trying the keys for
+the author identity found in the signed event until it finds one that can
+successfully verify the signature.
+
+The following example signs one or more events found in events.json, and
+immediately passes the signed events to the verifier.
+
+```
+eiffelsignature sign private_key.pem CN=joe ES512 < events.json | \
+    eiffelsignature verify /path/to/public-key-directory
+```
+
+## Supported algorithms
+
+| Algorithm | Meaning |
+|-----------|---------|
+| RS256     | RSASSA-PKCS1-v1_5 using SHA-256 |
+| RS384     | RSASSA-PKCS1-v1_5 using SHA-384 |
+| RS512     | RSASSA-PKCS1-v1_5 using SHA-512 |
+| ES256     | ECDSA using P-256 and SHA-256 |
+| ES384     | ECDSA using P-384 and SHA-384 |
+| ES512     | ECDSA using P-521 and SHA-512 |
+| PS256     | RSASSA-PSS using SHA-256 and MGF1 with SHA-256 |
+| PS384     | RSASSA-PSS using SHA-384 and MGF1 with SHA-384 |
+| PS512     | RSASSA-PSS using SHA-512 and MGF1 with SHA-512 |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | The signing or verification operation succeeded. |
+| 1    | The signing or verification operation completed, but unsuccessfully. |
+| 2    | The command never ran because command line arguments were malformed or missing. |
+
+## Keypair creation example
+
+The following commands create an ECDSA keypair in the form of two PEM
+files, one with the private key and one with the public key.
+
+```
+openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:secp521r1 -out private.pem
+openssl pkey -in private.pem -pubout -out public.pem
+```

--- a/cmd/eiffelsignature/main.go
+++ b/cmd/eiffelsignature/main.go
@@ -1,0 +1,66 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var ErrUsage = errors.New("invalid command line usage")
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	subcommand := os.Args[1]
+
+	var err error
+	switch subcommand {
+	case "sign":
+		err = signCmd(os.Args[2:], os.Stdin, os.Stdout)
+	case "verify":
+		err = verifyCmd(context.Background(), os.Args[2:], os.Stdin)
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", subcommand)
+		fmt.Fprintln(os.Stderr)
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if errors.Is(err, ErrUsage) {
+			fmt.Fprintln(os.Stderr)
+			usage()
+			os.Exit(2)
+		}
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s <command> <args>\n", filepath.Base(os.Args[0]))
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  sign <private key PEM file> <author identity DN> <algorithm>")
+	fmt.Fprintln(os.Stderr, "  verify <public key directory>")
+}

--- a/cmd/eiffelsignature/sign.go
+++ b/cmd/eiffelsignature/sign.go
@@ -80,8 +80,9 @@ func signCmd(args []string, in io.Reader, out io.Writer) error {
 	return nil
 }
 
-// loadPrivateKey attempts to read and parse a private key file. It supports
-// PEM-encoded RSA and ECDSA keys, as well as PKCS#8 (un-encrypted) keys.
+// loadPrivateKey attempts to read and parse a private key file encoded
+// as PEM. It supports RSA and ECDSA keys, either in their native
+// encodings (PKCS#1 and SEC1, respectively) or as PKCS#8.
 func loadPrivateKey(path string) (crypto.PrivateKey, error) {
 	pemData, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/eiffelsignature/sign.go
+++ b/cmd/eiffelsignature/sign.go
@@ -1,0 +1,115 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/eiffel-community/eiffelevents-sdk-go"
+	"github.com/eiffel-community/eiffelevents-sdk-go/signature"
+)
+
+func signCmd(args []string, in io.Reader, out io.Writer) error {
+	if len(args) < 3 {
+		return fmt.Errorf("%w: not enough arguments for sign command", ErrUsage)
+	}
+	keyFile := args[0]
+	identity := args[1]
+	alg := args[2]
+
+	priv, err := loadPrivateKey(keyFile)
+	if err != nil {
+		return fmt.Errorf("unable to load private key: %w", err)
+	}
+
+	signer, err := signature.NewKeySigner(identity, signature.Algorithm(alg), priv)
+	if err != nil {
+		return fmt.Errorf("unable to create key signer: %w", err)
+	}
+
+	decoder := json.NewDecoder(in)
+	for {
+		var payloadIn json.RawMessage
+
+		err := decoder.Decode(&payloadIn)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("unable to decode input stream: %w", err)
+		}
+
+		event, err := eiffelevents.UnmarshalAny(payloadIn)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal event: %w", err)
+		}
+
+		// We know the event we get from UnmarshalAny implements SigningSubject.
+		payloadOut, err := signer.Sign(event.(signature.SigningSubject)) // nolint:forcetypeassert
+		if err != nil {
+			return fmt.Errorf("unable to sign event: %w", err)
+		}
+
+		_, err = out.Write(payloadOut)
+		if err != nil {
+			return fmt.Errorf("unable to write signed event: %w", err)
+		}
+	}
+	return nil
+}
+
+// loadPrivateKey attempts to read and parse a private key file. It supports
+// PEM-encoded RSA and ECDSA keys, as well as PKCS#8 (un-encrypted) keys.
+func loadPrivateKey(path string) (crypto.PrivateKey, error) {
+	pemData, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for block, remaining := pem.Decode(pemData); block != nil; block, remaining = pem.Decode(remaining) {
+		switch block.Type {
+		case "RSA PRIVATE KEY":
+			if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+				return k, nil
+			}
+		case "EC PRIVATE KEY":
+			if k, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+				return k, nil
+			}
+		case "PRIVATE KEY":
+			if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+				switch pk := k.(type) {
+				case *rsa.PrivateKey, *ecdsa.PrivateKey:
+					return pk, nil
+				default:
+					return nil, fmt.Errorf("unsupported key type in PKCS#8: %T", k)
+				}
+			}
+		case "ENCRYPTED PRIVATE KEY":
+			return nil, fmt.Errorf("encrypted private keys are not supported")
+		}
+	}
+	return nil, fmt.Errorf("no suitable private key could be found in %s", path)
+}

--- a/cmd/eiffelsignature/signverify_test.go
+++ b/cmd/eiffelsignature/signverify_test.go
@@ -1,0 +1,85 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eiffel-community/eiffelevents-sdk-go"
+)
+
+// TestSignAndVerify is a simple smoke test for the eiffelsignature subcommands
+// that generates a keypair and an event, signs the event with the "sign" command
+// and verifies it with the "verify" command.
+func TestSignAndVerify(t *testing.T) {
+	dn := "CN=test"
+	privateKeyPath := filepath.Join(t.TempDir(), "private.pem")
+	publicKeyDir := t.TempDir()
+
+	createKeypairFiles(t, privateKeyPath, filepath.Join(publicKeyDir, dn+".pem"))
+
+	event, err := eiffelevents.NewCompositionDefinedV3()
+	require.NoError(t, err)
+	event.Data.Name = "my-composition"
+
+	var signedEvent bytes.Buffer
+	require.NoError(t, signCmd([]string{privateKeyPath, dn, "ES512"}, strings.NewReader(event.String()), &signedEvent))
+	require.NoError(t, verifyCmd(t.Context(), []string{publicKeyDir}, &signedEvent))
+}
+
+func createKeypairFiles(t *testing.T, privateKeyPath string, publicKeyFilePath string) {
+	// Generate a new ECDSA private key.
+	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	require.NoError(t, err)
+
+	// Encode the private to DER and marshal that to a PEM file.
+	privBytes, err := x509.MarshalECPrivateKey(privateKey)
+	require.NoError(t, err)
+
+	privateKeyFile, err := os.Create(privateKeyPath)
+	require.NoError(t, err)
+	defer privateKeyFile.Close()
+	err = pem.Encode(privateKeyFile, &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: privBytes,
+	})
+	require.NoError(t, err)
+
+	// Extract the public part of the key, encode to DER and marshal to a PEM file.
+	pubBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	require.NoError(t, err)
+
+	publicKeyFile, err := os.Create(publicKeyFilePath)
+	require.NoError(t, err)
+	defer publicKeyFile.Close()
+	err = pem.Encode(publicKeyFile, &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubBytes,
+	})
+	require.NoError(t, err)
+}

--- a/cmd/eiffelsignature/verify.go
+++ b/cmd/eiffelsignature/verify.go
@@ -1,0 +1,53 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/eiffel-community/eiffelevents-sdk-go/signature"
+)
+
+func verifyCmd(ctx context.Context, args []string, in io.Reader) error {
+	if len(args) < 1 {
+		return fmt.Errorf("%w: not enough arguments for verify command", ErrUsage)
+	}
+	keyDir := args[0]
+
+	locator := signature.NewFSPublicKeyLocator(signature.FSPublicKeyLocatorConfig{KeyDirectory: keyDir})
+	verifier := signature.NewVerifier(locator)
+	decoder := json.NewDecoder(in)
+	for {
+		var payloadIn json.RawMessage
+
+		err := decoder.Decode(&payloadIn)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("unable to decode input stream: %w", err)
+		}
+
+		if err := verifier.Verify(ctx, []byte(payloadIn)); err != nil {
+			return fmt.Errorf("unable to verify event signature: %w", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #112 

### Description of the Change
We add a simple executable that both serves as an example of how to use the signing APIs but also is useful on its own, e.g. to cross-check other implementations of signing or signature verification.

### Alternate Designs
The initial design was to have one binary for each operation (`eiffel-sign` and `eiffel-verify` or similar), but I realized there was no point in that.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>