### PR TITLE
validator: Add PackageURLValidator

### DIFF
--- a/validator/packageurlvalidator.go
+++ b/validator/packageurlvalidator.go
@@ -1,0 +1,56 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/tidwall/gjson"
+)
+
+// PackageURLValidator validates Package URL fields in selected event types.
+type PackageURLValidator struct{}
+
+func NewPackageURLValidator() *PackageURLValidator {
+	return &PackageURLValidator{}
+}
+
+// Validate validates the data.identity field as a package URL for
+// EiffelArtifactCreatedEvent events.
+func (pv *PackageURLValidator) Validate(_ context.Context, event []byte) error {
+	fields := gjson.GetManyBytes(event, "meta.type", "data.identity")
+
+	eventType := ""
+	if fields[0].Type == gjson.String {
+		eventType = fields[0].String()
+	}
+	if eventType != "EiffelArtifactCreatedEvent" {
+		return nil
+	}
+
+	if fields[1].Type != gjson.String || fields[1].String() == "" {
+		return fmt.Errorf("missing or invalid contents of data.identity field for %s", eventType)
+	}
+
+	if _, err := packageurl.FromString(fields[1].String()); err != nil {
+		return fmt.Errorf("invalid package URL in data.identity field for %s: %w", eventType, err)
+	}
+
+	return nil
+}

--- a/validator/packageurlvalidator_test.go
+++ b/validator/packageurlvalidator_test.go
@@ -1,0 +1,89 @@
+// Copyright Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	eiffelevents "github.com/eiffel-community/eiffelevents-sdk-go/editions/arica"
+)
+
+func TestPackageURLValidator(t *testing.T) {
+	testcases := []struct {
+		name          string
+		event         []byte
+		expectedError string
+	}{
+		{
+			name: "Non-ArtC event is ignored",
+			event: []byte(`{
+				"meta": {"type": "EiffelCompositionDefinedEvent"},
+				"data": {"identity": "not a purl"}
+			}`),
+		},
+		{
+			name: "ArtC event with valid purl",
+			event: []byte(`{
+				"meta": {"type": "EiffelArtifactCreatedEvent"},
+				"data": {"identity": "pkg:generic/example"}
+			}`),
+		},
+		{
+			name: "ArtC event with missing identity",
+			event: []byte(`{
+				"meta": {"type": "EiffelArtifactCreatedEvent"},
+				"data": {}
+			}`),
+			expectedError: "missing or invalid contents of data.identity",
+		},
+		{
+			name: "ArtC event with malformed purl",
+			event: []byte(`{
+				"meta": {"type": "EiffelArtifactCreatedEvent"},
+				"data": {"identity": "definitely-not-a-purl"}
+			}`),
+			expectedError: "invalid package URL in data.identity",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			validator := NewPackageURLValidator()
+			err := validator.Validate(t.Context(), tc.event)
+			if tc.expectedError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedError)
+		})
+	}
+}
+
+func TestDefaultSetValidatesArtifactCreatedIdentityPURL(t *testing.T) {
+	event, err := eiffelevents.NewArtifactCreated()
+	require.NoError(t, err)
+	event.Data.Identity = "pkg:"
+
+	err = DefaultSet().Validate(context.Background(), []byte(event.String()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid package URL in data.identity")
+}

--- a/validator/set.go
+++ b/validator/set.go
@@ -69,5 +69,6 @@ func DefaultSet() *ValidatorSet {
 			NewMetaSchemaLocator(http.DefaultClient),
 			NewBundledSchemaLocator(),
 		),
+		NewPackageURLValidator(),
 	)
 }


### PR DESCRIPTION
### Applicable Issues
Fixes #127

### Description of the Change
This validator inspects data.identity for ArtC and tries to pass that string to [github.com/package-url/packageurl-go](https://pkg.go.dev/github.com/package-url/packageurl-go) to check if it's a valid Package URL.

The new validator is also added to the default set of validators (which I guess is a backwards incompatible change).

### Alternate Designs
None.

### Possible Drawbacks
Making the new validator a part of the default set could create problems for people who unknowingly are sending events with invalid purls.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
